### PR TITLE
fix: correct 'investgiate' → 'investigate' and 'isses' → 'issues' typos

### DIFF
--- a/R/zi_aggregate.R
+++ b/R/zi_aggregate.R
@@ -155,7 +155,7 @@ zi_aggregate <- function(.data, year, extensive = NULL, intensive = NULL,
     valid <- zi_validate(zcta, style = "zcta3")
 
     if (valid == FALSE){
-      stop("ZCTA data passed to the 'zcta' argument are invalid. Please use 'zi_validate()' with the 'verbose = TRUE' option to investgiate further. The 'zi_repair()' function may be used to address issues.")
+      stop("ZCTA data passed to the 'zcta' argument are invalid. Please use 'zi_validate()' with the 'verbose = TRUE' option to investigate further. The 'zi_repair()' function may be used to address issues.")
     }
   }
 

--- a/R/zi_get_demographics.R
+++ b/R/zi_get_demographics.R
@@ -101,7 +101,7 @@ zi_get_demographics <- function(year, variables = NULL,
     valid <- zi_validate(zcta)
 
     if (valid == FALSE){
-      stop("ZCTA data passed to the 'zcta' argument are invalid. Please use 'zi_validate()' with the 'verbose = TRUE' option to investgiate further. The 'zi_repair()' function may be used to address isses.")
+      stop("ZCTA data passed to the 'zcta' argument are invalid. Please use 'zi_validate()' with the 'verbose = TRUE' option to investigate further. The 'zi_repair()' function may be used to address issues.")
     }
   }
 

--- a/R/zi_get_geometry.R
+++ b/R/zi_get_geometry.R
@@ -200,7 +200,7 @@ zi_get_geometry <- function(year, style = "zcta5", return = "id", class = "sf",
     valid <- zi_validate(includes, style = style)
 
     if (valid == FALSE){
-      stop("ZCTA data passed to the 'includes' argument are invalid. Please use 'zi_validate()' with the 'verbose = TRUE' option to investgiate further. The 'zi_repair()' function may be used to address issues.")
+      stop("ZCTA data passed to the 'includes' argument are invalid. Please use 'zi_validate()' with the 'verbose = TRUE' option to investigate further. The 'zi_repair()' function may be used to address issues.")
     }
   }
 
@@ -208,7 +208,7 @@ zi_get_geometry <- function(year, style = "zcta5", return = "id", class = "sf",
     valid <- zi_validate(excludes, style = style)
 
     if (valid == FALSE){
-      stop("ZCTA data passed to the 'excludes' argument are invalid. Please use 'zi_validate()' with the 'verbose = TRUE' option to investgiate further. The 'zi_repair()' function may be used to address issues.")
+      stop("ZCTA data passed to the 'excludes' argument are invalid. Please use 'zi_validate()' with the 'verbose = TRUE' option to investigate further. The 'zi_repair()' function may be used to address issues.")
     }
   }
 


### PR DESCRIPTION
## Problem

The typo "investgiate" (should be "investigate") appears in user-facing error messages in 4 files. Additionally, "isses" appears on line 104 of `zi_get_demographics.R`.

## Changes

- `R/zi_aggregate.R:158` — investgiate → investigate
- `R/zi_get_geometry.R:203,211` — investgiate → investigate
- `R/zi_get_demographics.R:104` — investgiate → investigate, isses → issues

## Verification

```bash
grep -rn 'investgiate\|isses' R/
# (should return nothing)
```

Closes #9