### PR TITLE
refactor: remove == TRUE / == FALSE anti-patterns

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,123 @@
+<!-- template-version: 1.1.0 -->
+<!-- Changelog: 1.1.0 adds Model routing section (2026-05-26) -->
+# Copilot Instructions — zippeR
+
+You are working in **`pfizer-opensource/zippeR`**. Tools for Working with ZIP Codes, ZCTAs, and 3-digit ZCTAs (R package)
+
+## What this repo is
+
+<!-- Replace this section with a 2–4 sentence description of the repo's purpose,
+     primary deliverables, and relationship to the EVGen ecosystem. -->
+
+This repo is an **EVGen consumer repo** that vendors cross-cutting workflow skills from `pfizer-evgen/rwd-agent-skills`. It follows the EVGen agent-driven development standard for issue management, PR ceremonies, and documentation.
+
+## Repo structure
+
+<!-- Adapt this section to match the actual directory layout of this repo.
+     The entries below are common starting points. -->
+
+- `.github/skills/*/SKILL.md` — workflow skills (vendored from upstream + any repo-specific skills)
+- `.github/skills/_partials/*.md` — composable fragments shared across skills
+- `.github/vendored-decisions/` — workflow-intrinsic ADRs (vendored from upstream)
+- `docs/decisions/` — repo-specific local ADRs
+- `.github/CONTRIBUTING.md` — operational contract (DoR, DoD, lifecycle)
+- `.github/LABELS.md` — canonical label vocabulary
+- `docs/` — documentation hub (architecture, roadmap, objectives, glossary, workflow)
+- `CHANGELOG.md` — user-facing release narrative
+
+## Skills
+
+Skills are the atomic unit of work in this repo. Each skill is a markdown file with YAML frontmatter (`filename`, `name`, `version`, `layout_version`, `triggers`, `description`) and a structured body following the v2 layout template (`## Activation`, `## Inputs`, `## Steps`, `## Outputs`, `## Success criteria`, `## Out of scope`, `## Cross-references`, `## Versioning`).
+
+### Skill versioning
+
+- Skills use semver: MAJOR.MINOR.PATCH.
+- MAJOR: breaking changes to the skill's contract (renamed operations, removed triggers, changed output format).
+- MINOR: new operations, new triggers, behavioral additions.
+- PATCH: bug fixes, wording clarifications, cross-reference updates.
+- Every version bump gets a CHANGELOG entry and a row in the skill's `## Versioning` table.
+
+### Partials
+
+Partials (`.github/skills/_partials/*.md`) are composable fragments included by reference in multiple skills. They carry a `<!-- partial-version: X.Y.Z -->` comment instead of full YAML frontmatter. Changes to a partial affect every consuming skill.
+
+### Model routing
+
+Each skill declares a recommended LLM tier in its `model:` frontmatter field (`opus`, `sonnet`, `haiku`). Agent personas declare `default_model:` similarly. See the upstream `docs/model-assignment-matrix.md` for the full mapping and rationale.
+
+**Tier guidelines:**
+- **Opus**: High-judgment work — architectural decisions, strategic prioritization, code review, discovery spikes
+- **Sonnet**: Implementation and documentation — most lifecycle skills, pattern-following work
+- **Haiku**: Mechanical bookends — quick capture, session start/handoff, post-merge cleanup
+
+**Hard ceiling: Opus 4.6.** Never use Opus 4.7 or higher due to billing constraints.
+
+**When delegating via task tool**, pass the `model` parameter based on the target persona's `default_model`:
+- Tech Lead / Product Owner → `claude-opus-4.5` (or `claude-opus-4.6` max)
+- Developer / Tech Writer / others → `claude-sonnet-4.5`
+- Mechanical sub-agents → `claude-haiku-4.5`
+
+Each skill displays its recommended tier at the top of its body. If the current model doesn't match, consider switching before high-judgment work.
+
+## Workflow
+
+The lifecycle is documented in `docs/WORKFLOW.md`. The skills directory is the source of truth for *how* each step is done. Key lifecycle skills:
+
+| Step | Skill |
+|---|---|
+| 0. Session start | `session_start/SKILL.md` |
+| 1. Discovery | `discovery/SKILL.md` |
+| 6. File issue | `backlog/SKILL.md`, `quick_capture/SKILL.md` |
+| 6a. Triage | `triage/SKILL.md` |
+| 7. Plan | `implementation_plan/SKILL.md` |
+| 8. Implement | (developer / agent) |
+| 9. Pre-PR | `pull_request/SKILL.md`, `code_review/SKILL.md` |
+| 10. Post-merge | `post_merge/SKILL.md` |
+
+## Conventions
+
+- **Filenames**: `<name>/SKILL.md` for skills (one-subdir-per-skill per ADR-0008); `kebab-case.md` for docs under `docs/`.
+- **ADRs**: `ADR-NNNN-kebab-case-title.md`. Monotonic, never reused, immutable once accepted.
+- **Issues**: every issue needs at least one Type label + one Priority label per `.github/LABELS.md`.
+- **Epics**: title format `[Epic <letter>] <theme>`. Epic letters are repo-scoped (A, B, C, ...).
+- **Commits**: conventional commits (`feat:`, `fix:`, `docs:`, `chore:`). GPG-signed.
+- **PRs**: five-section body per `.github/PULL_REQUEST_TEMPLATE.md`.
+
+## What NOT to do
+
+- Do NOT edit vendored-exact files to add repo-specific content. If a vendored file needs local customization, set `local_override: true` in this repo's `VENDOR_MANIFEST.json`.
+- Do NOT skip the changelog gate on PRs that bump skill versions.
+- Do NOT file ADRs for trivial decisions. ADRs are for structural choices that future sessions might re-litigate.
+
+## Workflow enforcement
+
+These rules are mandatory. Bypassing them defeats the lifecycle gates that maintain cross-session traceability.
+
+1. **Always use `pull_request/SKILL.md` to create or update PRs.** Never call `gh pr create` or `gh pr edit` directly. The PR skill enforces the plan-handoff hooks (Steps 1.5, 3.5), code-review gate (Step 2.5), retrospective (Step 3), changelog gate (Step 4), and Pre-PR QC gate (Step 4.5). Bypassing it silently skips all of these.
+
+2. **Always create a plan comment before implementing an issue.** Invoke `implementation_plan/SKILL.md` `Create` to post a `<!-- implementation-plan-v1 -->` comment on the issue before writing any implementation code. The plan comment is the cross-session state contract per [ADR-0005](vendored-decisions/ADR-0005-issue-comment-as-plan-contract.md). Without it, `pull_request/SKILL.md` Step 1.5 has nothing to hand off and Step 3.5 has nothing to transition.
+
+3. **Always use `gh` CLI for GitHub interactions — never MCP tools.** Do not use `github-mcp-server-*` tools for any GitHub API access (issues, PRs, labels, comments, commits, search). The `gh` CLI authenticates via the user's pre-authorized token and works reliably in organizations with OAuth App access restrictions. MCP tool attempts fail silently or with opaque errors in these environments, wasting time and producing noisy logs.
+
+<!-- ============================================================
+     Pre-PR QC checklist (read by pull_request/SKILL.md Step 4.5c)
+     Add repo-specific QC steps below. Each line should be a
+     concrete, verifiable check the agent runs before opening a PR.
+     ============================================================ -->
+
+## Human-in-the-loop: R/ source changes
+
+Any changes to scripts in the `R/` folder require **User Acceptance Testing (UAT)** before merging. When a PR touches files in `R/`:
+
+1. Flag the PR explicitly for UAT in the PR body and in chat.
+2. Do NOT merge or mark the task as complete until the user has confirmed acceptance.
+3. Present a summary of functional changes to `R/` scripts and ask the user to verify correctness.
+
+This applies to all modifications — new files, refactors, bug fixes, and style changes within `R/`.
+
+## Pre-PR QC checklist
+
+- Flag any `R/` file changes for UAT and confirm user sign-off before PR creation.
+<!-- - Run `tests/meta/validate_frontmatter.py` and confirm 0 errors. -->
+<!-- - Run dataset-level QC for each touched dataset under `datasets/`. -->
+<!-- - Confirm `.gitignore` patterns exclude all generated data files. -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,5 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Remove `== TRUE` / `== FALSE` anti-patterns across all R/ sources (#11)
+
 ### Added
 - EVGen workflow scaffolding vendored from pfizer-evgen/rwd-agent-skills

--- a/R/zi_aggregate.R
+++ b/R/zi_aggregate.R
@@ -109,15 +109,15 @@ zi_aggregate <- function(.data, year, extensive = NULL, intensive = NULL,
     stop("The 'survey' requested is invalid. Please choose one of 'sf1', 'sf3', 'acs1', 'acs3', or 'acs5'.")
   }
 
-  if (survey %in% c("sf1", "sf3") == TRUE & year != 2010){
+  if (survey %in% c("sf1", "sf3") & year != 2010){
     stop("The 'year' value provided is invalid for Decennial Census data. Only 2010 may be requested currently.")
   }
 
-  if (survey %in% c("acs1", "acs5") == TRUE & year %in% c(2010:2022) == FALSE){
+  if (survey %in% c("acs1", "acs5") & !(year %in% c(2010:2022))){
     stop("The 'year' value provided is invalid for 1- or 5-year American Community Survey data. Please provide a year between 2010 and 2022.")
   }
 
-  if (survey == "acs3" & year %in% c(2010:2013) == FALSE){
+  if (survey == "acs3" & !(year %in% c(2010:2013))){
     stop("The 'year' value provided is invalid for 3-year American Community Survey data. Please provide a year between 2010 and 2013.")
   }
 
@@ -136,17 +136,17 @@ zi_aggregate <- function(.data, year, extensive = NULL, intensive = NULL,
       stop(error)
     }
 
-    if (all(names(.data) == c("GEOID", "variable", "value")) == FALSE){
+    if (!all(names(.data) == c("GEOID", "variable", "value"))){
       stop(error)
     }
-  } else if (survey %in% c("acs1", "acs3", "acs5") == TRUE){
+  } else if (survey %in% c("acs1", "acs3", "acs5")){
     error <- "Input data appear to be malformed - there should be four columns for ACS data: 'GEOID', 'variable', 'estimate', and 'moe'. Note that zi_aggregate() only accepts 'tidy' data."
 
     if (length(names(.data)) != 4){
       stop(error)
     }
 
-    if (all(names(.data) == c("GEOID", "variable", "estimate", "moe")) == FALSE){
+    if (!all(names(.data) == c("GEOID", "variable", "estimate", "moe"))){
       stop(error)
     }
   }
@@ -154,7 +154,7 @@ zi_aggregate <- function(.data, year, extensive = NULL, intensive = NULL,
   if (!is.null(zcta)){
     valid <- zi_validate(zcta, style = "zcta3")
 
-    if (valid == FALSE){
+    if (!valid){
       stop("ZCTA data passed to the 'zcta' argument are invalid. Please use 'zi_validate()' with the 'verbose = TRUE' option to investigate further. The 'zi_repair()' function may be used to address issues.")
     }
   }
@@ -182,15 +182,15 @@ zi_aggregate <- function(.data, year, extensive = NULL, intensive = NULL,
   .data <- dplyr::arrange(.data, ZCTA3)
 
   # call underlying tidycensus data
-  if (survey %in% c("sf1", "sf3") == TRUE){
+  if (survey %in% c("sf1", "sf3")){
 
     ## summarize data
-    if (extensive_id == TRUE & intensive_id == FALSE){
+    if (extensive_id & !intensive_id){
 
       ## aggregate
       out <- zi_census_extensive(.data)
 
-    } else if (extensive_id == FALSE & intensive_id == TRUE){
+    } else if (!extensive_id & intensive_id){
 
       ## calculate weights
       weights <- zi_census_weights(year = year, key = key)
@@ -202,11 +202,11 @@ zi_aggregate <- function(.data, year, extensive = NULL, intensive = NULL,
         out <- NULL
       }
 
-    } else if (extensive_id == TRUE & intensive_id == TRUE){
+    } else if (extensive_id & intensive_id){
 
       ## subset data
-      extensive_df <- dplyr::filter(.data, variable %in% extensive == TRUE)
-      intensive_df <- dplyr::filter(.data, variable %in% intensive == TRUE)
+      extensive_df <- dplyr::filter(.data, variable %in% extensive)
+      intensive_df <- dplyr::filter(.data, variable %in% intensive)
 
       ## calculate weights
       weights <- zi_census_weights(year = year, key = key)
@@ -225,15 +225,15 @@ zi_aggregate <- function(.data, year, extensive = NULL, intensive = NULL,
 
     }
 
-  } else if (survey %in% c("acs1", "acs3", "acs5") == TRUE){
+  } else if (survey %in% c("acs1", "acs3", "acs5")){
 
     ## summarize data
-    if (extensive_id == TRUE & intensive_id == FALSE){
+    if (extensive_id & !intensive_id){
 
       ## aggregate
       out <- zi_acs_extensive(.data)
 
-    } else if (extensive_id == FALSE & intensive_id == TRUE){
+    } else if (!extensive_id & intensive_id){
 
       ## calculate weights
       weights <- zi_acs_weights(year = year, survey = survey, key = key)
@@ -245,11 +245,11 @@ zi_aggregate <- function(.data, year, extensive = NULL, intensive = NULL,
         out <- NULL
       }
 
-    } else if (extensive_id == TRUE & intensive_id == TRUE){
+    } else if (extensive_id & intensive_id){
 
       ## subset data
-      extensive_df <- dplyr::filter(.data, variable %in% extensive == TRUE)
-      intensive_df <- dplyr::filter(.data, variable %in% intensive == TRUE)
+      extensive_df <- dplyr::filter(.data, variable %in% extensive)
+      intensive_df <- dplyr::filter(.data, variable %in% intensive)
 
       ## calculate weights
       weights <- zi_acs_weights(year = year, survey = survey, key = key)
@@ -271,8 +271,8 @@ zi_aggregate <- function(.data, year, extensive = NULL, intensive = NULL,
 
   if (!is.null(out)){
     # optionally subset
-    if (is.null(zcta) == FALSE){
-      out <- dplyr::filter(out, ZCTA3 %in% zcta == TRUE)
+    if (!is.null(zcta)){
+      out <- dplyr::filter(out, ZCTA3 %in% zcta)
     }
 
     # optionally pivot

--- a/R/zi_convert.R
+++ b/R/zi_convert.R
@@ -45,20 +45,20 @@ zi_convert <- function(.data, input_var, output_var){
 
   input_varQN <- as.character(substitute(input_var))
 
-  if (input_varQN %in% names(.data) == FALSE){
+  if (!(input_varQN %in% names(.data))){
     stop("The given 'input_var' column is not found in your data object.")
   }
 
   valid <- zi_validate(x = .data[[input_varQN]])
 
-  if (valid == FALSE){
+  if (!valid){
     stop(paste0("Input ZIP Code data in the '", input_varQN, "' column are invalid. Please use 'zi_validate()' with the 'verbose = TRUE' option to investigate further. The 'zi_repair()' function may be used to address issues."))
   }
 
   if (!missing(output_var)){
     output_varQN <- as.character(substitute(input_var))
 
-    if (output_varQN %in% names(.data) == TRUE){
+    if (output_varQN %in% names(.data)){
       warning(paste0("The given 'output_var' column, '", output_varQN , "', was found in your data object, and the column was overwritten."))
     }
   } else {

--- a/R/zi_crosswalk.R
+++ b/R/zi_crosswalk.R
@@ -112,13 +112,13 @@ zi_crosswalk <- function(.data, input_var, zip_source = "UDS", source_var,
 
   input_varQN <- as.character(substitute(input_var))
 
-  if (input_varQN %in% names(.data) == FALSE){
+  if (!(input_varQN %in% names(.data))){
     stop("The given 'input_var' column is not found in your input object.")
   }
 
   valid <- zi_validate(x = .data[[input_varQN]])
 
-  if (valid == FALSE){
+  if (!valid){
     stop(paste0("Input ZIP Code data in the '", input_varQN, "' column are invalid. Please use 'zi_validate()' with the 'verbose = TRUE' option to investigate further. The 'zi_repair()' function may be used to address issues."))
   }
 
@@ -135,13 +135,13 @@ zi_crosswalk <- function(.data, input_var, zip_source = "UDS", source_var,
 
     source_varQN <- as.character(substitute(source_var))
 
-    if (source_varQN %in% names(zip_source) == FALSE){
+    if (!(source_varQN %in% names(zip_source))){
       stop("The given 'source_var' column is not found in your dictionary object.")
     }
 
     valid <- zi_validate(x = zip_source[[source_varQN]], style = "zcta5")
 
-    if (valid == FALSE){
+    if (!valid){
       stop(paste0("Dictionary ZCTA data in the '", source_varQN, "' column are invalid. Please use 'zi_validate()' with the 'verbose = TRUE' option to investigate further. The 'zi_repair()' function may be used to address issues."))
     }
 
@@ -151,35 +151,35 @@ zi_crosswalk <- function(.data, input_var, zip_source = "UDS", source_var,
 
     source_resultQN <- as.character(substitute(source_result))
 
-    if (source_resultQN %in% names(zip_source) == FALSE){
+    if (!(source_resultQN %in% names(zip_source))){
       stop("The given 'source_result' column is not found in your dictionary object.")
     }
 
   } else if (workflow == "api"){
 
-    if (is.numeric(year) == FALSE){
+    if (!is.numeric(year)){
       stop("The 'year' value provided is invalid. Please provide a numeric value for the requested year.")
     }
 
-    if (zip_source == "UDS" & year %in% c(2009:2022) == FALSE){
+    if (zip_source == "UDS" & !(year %in% c(2009:2022))){
       stop("The 'year' value provided is invalid for UDS data. Please provide a year between 2009 and 2022.")
     }
 
     if (zip_source == "HUD"){
 
-      if (year %in% c(2010:2024) == FALSE){
+      if (!(year %in% c(2010:2024))){
         stop("The 'year' value provided is invalid for HUD data. Please provide a year between 2010 and 2024.")
       }
 
-      if (qtr %in% c(1:4) == FALSE){
+      if (!(qtr %in% c(1:4))){
         stop("The 'qtr' value is required when 'zip_source' is 'HUD'. Please provide a value between 1 and 4.")
       }
 
-      if (target %in% c("TRACT", "COUNTY", "CBSA", "CBSADIV", "CD", "COUNTYSUB") == FALSE){
+      if (!(target %in% c("TRACT", "COUNTY", "CBSA", "CBSADIV", "CD", "COUNTYSUB"))){
         stop("The 'target' value is required when 'zip_source' is 'HUD'. Please provide a valid target value (see help file).")
       }
 
-      if (is.null(query) == TRUE){
+      if (is.null(query)){
         stop("The 'query' value is required when 'zip_source' is 'HUD'. Please provide a valid query value (see help file).")
       }
 
@@ -187,7 +187,7 @@ zi_crosswalk <- function(.data, input_var, zip_source = "UDS", source_var,
         stop("A valid value for 'by' value is required. Please input either 'residential', 'commercial', or 'total'.")
       }
 
-      if (by %in% c("residential", "commercial", "total") == FALSE){
+      if (!(by %in% c("residential", "commercial", "total"))){
         stop("The 'by' value provided is invalid. Please input either 'residential', 'commercial', or 'total'.")
       }
 

--- a/R/zi_get_demographics.R
+++ b/R/zi_get_demographics.R
@@ -61,11 +61,11 @@ zi_get_demographics <- function(year, variables = NULL,
                                 zcta = NULL, key = NULL){
 
   # check inputs
-  if (missing(year) == TRUE){
+  if (missing(year)){
     stop("The 'year' value is missing. Please provide a numeric value between 2010 and 2022.")
   }
 
-  if (is.numeric(year) == FALSE){
+  if (!is.numeric(year)){
     stop("The 'year' value provided is invalid. Please provide a numeric value between 2010 and 2022.")
   }
 
@@ -73,34 +73,34 @@ zi_get_demographics <- function(year, variables = NULL,
     stop("One only 'survey' product may be requested at a time.")
   }
 
-  if (survey %in% c("sf1", "sf3", "acs1", "acs3", "acs5") == FALSE){
+  if (!(survey %in% c("sf1", "sf3", "acs1", "acs3", "acs5"))){
     stop("The 'survey' requested is invalid. Please choose one of 'sf1', 'sf3', 'acs1', 'acs3', or 'acs5'.")
   }
 
-  if (survey %in% c("sf1", "sf3") == TRUE & year != 2010){
+  if (survey %in% c("sf1", "sf3") & year != 2010){
     stop("The 'year' value provided is invalid for Decennial Census data. Only 2010 may be requested currently.")
   }
 
-  if (survey %in% c("acs1", "acs5") == TRUE & year %in% c(2010:2022) == FALSE){
+  if (survey %in% c("acs1", "acs5") & !(year %in% c(2010:2022))){
     stop("The 'year' value provided is invalid for 1- or 5-year American Community Survey data. Please provide a year between 2010 and 2022.")
   }
 
-  if (survey == "acs3" & year %in% c(2010:2013) == FALSE){
+  if (survey == "acs3" & !(year %in% c(2010:2013))){
     stop("The 'year' value provided is invalid for 3-year American Community Survey data. Please provide a year between 2010 and 2013.")
   }
 
-  if (is.null(variables) == FALSE & is.null(table) == FALSE){
+  if (!is.null(variables) & !is.null(table)){
     stop("The 'variables' or 'table' arguments cannot be used simultaneously. Please choose one or the other.")
   }
 
-  if (output %in% c("tidy", "wide") == FALSE){
+  if (!(output %in% c("tidy", "wide"))){
     stop("The 'output' requested is invalid. Please choose one of 'tidy' or 'wide'.")
   }
 
-  if (is.null(zcta) == FALSE){
+  if (!is.null(zcta)){
     valid <- zi_validate(zcta)
 
-    if (valid == FALSE){
+    if (!valid){
       stop("ZCTA data passed to the 'zcta' argument are invalid. Please use 'zi_validate()' with the 'verbose = TRUE' option to investigate further. The 'zi_repair()' function may be used to address issues.")
     }
   }
@@ -134,8 +134,8 @@ zi_get_demographics <- function(year, variables = NULL,
     out <- dplyr::arrange(out, GEOID)
 
     ## optionally subset
-    if (is.null(zcta) == FALSE){
-      out <- dplyr::filter(out, GEOID %in% zcta == TRUE)
+    if (!is.null(zcta)){
+      out <- dplyr::filter(out, GEOID %in% zcta)
     }
   }
 

--- a/R/zi_get_geometry.R
+++ b/R/zi_get_geometry.R
@@ -129,19 +129,19 @@ zi_get_geometry <- function(year, style = "zcta5", return = "id", class = "sf",
                             excludes = NULL, method = NULL, shift_geo = FALSE){
 
   # check inputs
-  if (is.numeric(year) == FALSE){
+  if (!is.numeric(year)){
     stop("The 'year' value provided is invalid. Please provide a numeric value between years 2010 and 2023.")
   }
 
-  if (year %in% c(2010:2023) == FALSE){
+  if (!(year %in% c(2010:2023))){
     stop("The 'year' value provided is invalid. Please provide a year between 2010 and 2023.")
   }
 
-  if (style %in% c("zcta5", "zcta3") == FALSE){
+  if (!(style %in% c("zcta5", "zcta3"))){
     stop("The 'style' value provided is invalid. Please select either 'zcta5' or 'zcta3'.")
   }
 
-  if (return %in% c("id", "full") == FALSE){
+  if (!(return %in% c("id", "full"))){
     stop("The 'return' value provided is invalid. Please select either 'id' or 'full'.")
   }
 
@@ -149,65 +149,65 @@ zi_get_geometry <- function(year, style = "zcta5", return = "id", class = "sf",
     warning("The 'full' option for 'return' is not available for 'zcta3' data. Please use 'id' instead.")
   }
 
-  if (style == "zcta3" & cb == TRUE){
+  if (style == "zcta3" & cb){
     warning("The 'cb' argument does not apply to 'zcta3' data.")
   }
 
-  if (is.logical(shift_geo) == FALSE){
+  if (!is.logical(shift_geo)){
     stop("The 'shift_geo' value provided is invalid. Please select either 'TRUE' or 'FALSE'.")
   }
 
-  if (shift_geo == TRUE & is.null(state) == FALSE){
+  if (shift_geo & !is.null(state)){
     stop("The 'shift_geo' functionality can only be used when you are returning data for all states.")
   }
 
-  if (any(state %in% c("AS", "GU", "MP", "PR", "VI")) == TRUE){
+  if (any(state %in% c("AS", "GU", "MP", "PR", "VI"))){
     stop("Please specify territories using the 'territory' argument instead. Valid territories are: 'AS', 'GU', 'MP', 'PR', or 'VI' (or their equivalent FIPS codes).")
   }
 
-  if (is.null(state) == FALSE){
+  if (!is.null(state)){
     state <- unlist(sapply(state, validate_state, USE.NAMES=FALSE))
   }
 
-  if (is.null(county) == FALSE & is.null(state) == TRUE){
+  if (!is.null(county) & is.null(state)){
     stop("Please provide at least one state abbreviation or FIPS code for the 'state' argument that corresponds to data passed to the 'county' argument.")
   }
 
-  if (is.null(state) == FALSE & missing(method) == TRUE){
+  if (!is.null(state) & missing(method)){
     stop("Please select a valid method for returning ZCTA values. Your choices are 'centroid' and 'intersect'. See documentation for details.")
     }
 
   if (!is.null(method)){
-    if (method %in% c("centroid", "intersect") == FALSE){
+    if (!(method %in% c("centroid", "intersect"))){
       stop("The two valid methods for returning ZCTA values are 'centroid' and 'intersect'. See documentation for details.")
     }
   }
 
   ## validate counties
-  if (is.null(territory) == FALSE & any(territory %in% c("AS", "GU", "MP", "PR", "VI")) == FALSE){
+  if (!is.null(territory) & !any(territory %in% c("AS", "GU", "MP", "PR", "VI"))){
     stop("An abbreviation given for the 'territory' argument is invalid. Please use one or more of: 'AS', 'GU', 'MP', 'PR', or 'VI' (or their equivalent FIPS codes).")
     }
 
-  if (is.null(starts_with) == FALSE){
+  if (!is.null(starts_with)){
     valid <- zi_validate_starts(starts_with)
 
-    if (valid == FALSE){
+    if (!valid){
       stop("ZCTA data passed to the 'starts_with' argument are invalid. Please use a character vector with only two-digit values.")
     }
   }
 
-  if (is.null(includes) == FALSE){
+  if (!is.null(includes)){
     valid <- zi_validate(includes, style = style)
 
-    if (valid == FALSE){
+    if (!valid){
       stop("ZCTA data passed to the 'includes' argument are invalid. Please use 'zi_validate()' with the 'verbose = TRUE' option to investigate further. The 'zi_repair()' function may be used to address issues.")
     }
   }
 
-  if (is.null(excludes) == FALSE){
+  if (!is.null(excludes)){
     valid <- zi_validate(excludes, style = style)
 
-    if (valid == FALSE){
+    if (!valid){
       stop("ZCTA data passed to the 'excludes' argument are invalid. Please use 'zi_validate()' with the 'verbose = TRUE' option to investigate further. The 'zi_repair()' function may be used to address issues.")
     }
   }
@@ -238,7 +238,7 @@ zi_get_geometry <- function(year, style = "zcta5", return = "id", class = "sf",
 
   # finalize output
   if (!is.null(out)){
-    if (class == "sf" & shift_geo == TRUE){
+    if (class == "sf" & shift_geo){
 
       ## shift geometry
       out <- tigris::shift_geometry(out, position = "below")
@@ -273,14 +273,14 @@ zi_get_zcta5 <- function(year, return = "id", state, county, territory, cb,
 
   # process geometry
   if (!is.null(out)){
-    if (is.null(state) == FALSE & is.null(county) == TRUE) {
+    if (!is.null(state) & is.null(county)) {
 
       ## generate vector of requested state ZCTAs
       zcta_vec <- zi_list_zctas(year = year, state = c(state, territory), method = method)
 
       ## add inclusions, remove exclusions
       zcta_vec <- unique(c(zcta_vec, includes))
-      zcta_vec <- zcta_vec[zcta_vec %in% excludes == FALSE]
+      zcta_vec <- zcta_vec[!(zcta_vec %in% excludes)]
 
       ## rename year
       if (year < 2020){
@@ -290,9 +290,9 @@ zi_get_zcta5 <- function(year, return = "id", state, county, territory, cb,
       }
 
       ## subset
-      out <- dplyr::filter(out, GEOID %in% zcta_vec == TRUE)
+      out <- dplyr::filter(out, GEOID %in% zcta_vec)
 
-    } else if (is.null(state) == FALSE & is.null(county) == FALSE){
+    } else if (!is.null(state) & !is.null(county)){
 
       ## geoprocess based on county to produced vector of ZCTAs
       zcta_vec <- zi_process_county(cb = cb, state = c(state, territory), county = county,
@@ -302,7 +302,7 @@ zi_get_zcta5 <- function(year, return = "id", state, county, territory, cb,
       if (!is.null(zcta_vec)){
         ## add inclusions, remove exclusions
         zcta_vec <- unique(c(zcta_vec, includes))
-        zcta_vec <- zcta_vec[zcta_vec %in% excludes == FALSE]
+        zcta_vec <- zcta_vec[!(zcta_vec %in% excludes)]
 
         ## rename year
         if (year < 2020){
@@ -312,12 +312,12 @@ zi_get_zcta5 <- function(year, return = "id", state, county, territory, cb,
         }
 
         ## subset
-        out <- dplyr::filter(out, GEOID %in% zcta_vec == TRUE)
+        out <- dplyr::filter(out, GEOID %in% zcta_vec)
       } else {
         out <- NULL
       }
 
-    } else if (is.null(state) == TRUE & is.null(county) == TRUE){
+    } else if (is.null(state) & is.null(county)){
 
       ## rename year
       if (year < 2020){
@@ -327,23 +327,23 @@ zi_get_zcta5 <- function(year, return = "id", state, county, territory, cb,
       }
 
       ## manage territories
-      if (is.null(territory) == TRUE){
+      if (is.null(territory)){
 
         ## all territories not including American Samoa
-        out <- dplyr::filter(out, substr(GEOID, 1,3) %in% c("006", "007", "008", "009", "969") == FALSE)
+        out <- dplyr::filter(out, !(substr(GEOID, 1,3) %in% c("006", "007", "008", "009", "969")))
 
         ## American Samoa
         out <- dplyr::filter(out, GEOID != "96799")
 
-      } else if (is.null(territory) == FALSE){
+      } else if (!is.null(territory)){
 
         ## territory vector
         territory_vec <- c("AS", "GU", "MP", "PR", "VI")
 
-        if (all(territory == territory_vec) == FALSE){
+        if (!all(territory == territory_vec)){
 
           ## construct list
-          territory_vec <- territory_vec[territory_vec %in% territory == FALSE]
+          territory_vec <- territory_vec[!(territory_vec %in% territory)]
 
           ## create vector
           zcta_vec <- zi_list_zctas(year = year, state = territory_vec, method = "intersect")
@@ -355,16 +355,16 @@ zi_get_zcta5 <- function(year, return = "id", state, county, territory, cb,
       }
 
       ## subset
-      if (is.null(excludes) == FALSE){
-        out <- dplyr::filter(out, GEOID %in% excludes == FALSE)
+      if (!is.null(excludes)){
+        out <- dplyr::filter(out, !(GEOID %in% excludes))
       }
 
     }
 
     # subset based on starts with
     if (!is.null(out)){
-      if (is.null(starts_with) == FALSE){
-        out <- dplyr::filter(out, substr(GEOID, 1, 2) %in% starts_with == TRUE)
+      if (!is.null(starts_with)){
+        out <- dplyr::filter(out, substr(GEOID, 1, 2) %in% starts_with)
       }
 
       # subset columns based on return
@@ -444,7 +444,7 @@ zi_get_zcta3 <- function(year, state, county, territory, cb, starts_with,
   out <- sf::st_read(zcta3_url[[val]], quiet = TRUE)
 
   # process geometry
-  if (is.null(state) == FALSE & is.null(county) == TRUE) {
+  if (!is.null(state) & is.null(county)) {
 
     ## generate vector of requested state ZCTAs
     zcta_vec <- zi_list_zctas(year = year, state = c(state, territory), method = method)
@@ -452,16 +452,16 @@ zi_get_zcta3 <- function(year, state, county, territory, cb, starts_with,
 
     ## add inclusions, remove exclusions
     zcta_vec <- unique(c(zcta_vec, includes))
-    zcta_vec <- zcta_vec[zcta_vec %in% excludes == FALSE]
+    zcta_vec <- zcta_vec[!(zcta_vec %in% excludes)]
 
     ## subset based on year
     if (year < 2020){
-      out <- dplyr::filter(out, ZCTA3 %in% zcta_vec == TRUE)
+      out <- dplyr::filter(out, ZCTA3 %in% zcta_vec)
     } else if (year >= 2020){
-      out <- dplyr::filter(out, ZCTA3 %in% zcta_vec == TRUE)
+      out <- dplyr::filter(out, ZCTA3 %in% zcta_vec)
     }
 
-  } else if (is.null(state) == FALSE & is.null(county) == FALSE){
+  } else if (!is.null(state) & !is.null(county)){
 
     ## geoprocess based on county to produced vector of ZTAs
     zcta_vec <- zi_process_county(cb = cb, state = c(state, territory), county = county,
@@ -471,40 +471,40 @@ zi_get_zcta3 <- function(year, state, county, territory, cb, starts_with,
     if (!is.null(zcta_vec)){
       ## add inclusions, remove exclusions
       zcta_vec <- unique(c(zcta_vec, includes))
-      zcta_vec <- zcta_vec[zcta_vec %in% excludes == FALSE]
+      zcta_vec <- zcta_vec[!(zcta_vec %in% excludes)]
 
       ## subset based on year
-      out <- dplyr::filter(out, ZCTA3 %in% zcta_vec == TRUE)
+      out <- dplyr::filter(out, ZCTA3 %in% zcta_vec)
     } else {
       out <- NULL
     }
 
-  } else if (is.null(state) == TRUE & is.null(county) == TRUE){
+  } else if (is.null(state) & is.null(county)){
 
     ## manage territories
-    if (is.null(territory) == TRUE){
+    if (is.null(territory)){
 
       ## all territories not including American Samoa
-      out <- dplyr::filter(out, ZCTA3 %in% c("006", "007", "008", "009", "969") == FALSE)
+      out <- dplyr::filter(out, !(ZCTA3 %in% c("006", "007", "008", "009", "969")))
 
       ## American Samoa
       out <- sf::st_difference(out, samoa_bounding_box)
 
-    } else if (is.null(territory) == FALSE){
+    } else if (!is.null(territory)){
 
       ## territory vector
       territory_vec <- c("AS", "GU", "MP", "PR", "VI")
 
-      if (all(territory == territory_vec) == FALSE){
+      if (!all(territory == territory_vec)){
 
         ## construct vector
-        territory_vec <- territory_vec[territory_vec %in% territory == FALSE]
+        territory_vec <- territory_vec[!(territory_vec %in% territory)]
 
         ## remove American Samoa from vector list
-        if ("AS" %in% territory_vec == TRUE){
+        if ("AS" %in% territory_vec){
 
           ## revise vector
-          territory_vec <- territory_vec[territory_vec %in% c("AS") == FALSE]
+          territory_vec <- territory_vec[!(territory_vec %in% c("AS"))]
 
           ## geoprocess
           out <- sf::st_difference(out, samoa_bounding_box)
@@ -522,16 +522,16 @@ zi_get_zcta3 <- function(year, state, county, territory, cb, starts_with,
     }
 
     ## remove exclusions
-    if (is.null(excludes) == FALSE){
-      out <- dplyr::filter(out, ZCTA3 %in% excludes == FALSE)
+    if (!is.null(excludes)){
+      out <- dplyr::filter(out, !(ZCTA3 %in% excludes))
     }
 
   }
 
   # subset based on starts with
   if (!is.null(out)){
-    if (is.null(starts_with) == FALSE){
-      out <- dplyr::filter(out, substr(ZCTA3, 1, 2) %in% starts_with == TRUE)
+    if (!is.null(starts_with)){
+      out <- dplyr::filter(out, substr(ZCTA3, 1, 2) %in% starts_with)
     }
 
     # order output
@@ -547,7 +547,7 @@ zi_get_zcta3 <- function(year, state, county, territory, cb, starts_with,
 zi_validate_starts <- function(x){
 
   # ensure character
-  if (is.character(x) == FALSE){
+  if (!is.character(x)){
     chr_out <- FALSE
   } else {
     chr_out <- TRUE

--- a/R/zi_label.R
+++ b/R/zi_label.R
@@ -100,7 +100,7 @@ zi_label <- function(.data, input_var, label_source = "UDS", source_var,
 
   input_varQN <- as.character(substitute(input_var))
 
-  if (input_varQN %in% names(.data) == FALSE){
+  if (!(input_varQN %in% names(.data))){
     stop("The given 'input_var' column is not found in your input object.")
   }
 
@@ -114,7 +114,7 @@ zi_label <- function(.data, input_var, label_source = "UDS", source_var,
 
   valid <- zi_validate(x = .data[[input_varQN]], style = type_zcta)
 
-  if (valid == FALSE){
+  if (!valid){
     stop(paste0("Input ZIP Code data in the '", input_varQN, "' column are invalid. Please use 'zi_validate()' with the 'verbose = TRUE' option to investigate further. The 'zi_repair()' function may be used to address issues."))
   }
 
@@ -127,13 +127,13 @@ zi_label <- function(.data, input_var, label_source = "UDS", source_var,
 
     source_varQN <- as.character(substitute(source_var))
 
-    if (source_varQN %in% names(label_source) == FALSE){
+    if (!(source_varQN %in% names(label_source))){
       stop("The given 'source_var' column is not found in your dictionary object.")
     }
 
     valid <- zi_validate(x = label_source[[source_varQN]], style = type_zcta)
 
-    if (valid == FALSE){
+    if (!valid){
       stop(paste0("Dictionary ZCTA data in the '", source_varQN, "' column are invalid. Please use 'zi_validate()' with the 'verbose = TRUE' option to investigate further. The 'zi_repair()' function may be used to address issues."))
     }
 
@@ -145,7 +145,7 @@ zi_label <- function(.data, input_var, label_source = "UDS", source_var,
         stop("The 'UDS' source only provides ZIP5 data, replace 'type' with 'zip5'.")
       }
 
-      if (is.numeric(vintage) == FALSE){
+      if (!is.numeric(vintage)){
         vintage_num <- as.numeric(vintage)
       } else {
         vintage_num <- vintage
@@ -155,7 +155,7 @@ zi_label <- function(.data, input_var, label_source = "UDS", source_var,
         stop("The 'UDS' source only provides ZIP5 data between 2009 and 2022.")
       }
 
-      if (include_scf == TRUE){
+      if (include_scf){
         warning("The 'include_scf' argument only modifies the output of 'zip3' labels.")
       }
 
@@ -165,7 +165,7 @@ zi_label <- function(.data, input_var, label_source = "UDS", source_var,
         stop("The 'USPS' source only provides ZIP3 data, replace 'type' with 'zip3'.")
       }
 
-      if (is.numeric(vintage) == TRUE){
+      if (is.numeric(vintage)){
         vintage_chr <- as.character(vintage)
       } else {
         vintage_chr <- vintage

--- a/R/zi_list_zctas.R
+++ b/R/zi_list_zctas.R
@@ -46,27 +46,27 @@
 zi_list_zctas <- function(year, state, method){
 
   # check inputs
-  if (missing(year) == TRUE){
+  if (missing(year)){
     stop("The 'year' value is missing. Please provide a numeric value between 2010 and 2023.")
   }
 
-  if (is.numeric(year) == FALSE){
+  if (!is.numeric(year)){
     stop("The 'year' value provided is invalid. Please provide a numeric value between years 2010 and 2023.")
   }
 
-  if (year %in% c(2010:2023) == FALSE){
+  if (!(year %in% c(2010:2023))){
     stop("The 'year' value provided is invalid. Please provide a numeric value between years 2010 and 2023.")
   }
 
-  if (missing(state) == TRUE){
+  if (missing(state)){
     stop("Please provide a vector of valid state abbreviations for the 'state' argument.")
   }
 
-  if (missing(method) == TRUE){
+  if (missing(method)){
     stop("Please select a valid method for returning ZCTA values. Your choices are 'centroid' and 'intersect'. See documentation for details.")
   }
 
-  if (method %in% c("centroid", "intersect") == FALSE){
+  if (!(method %in% c("centroid", "intersect"))){
     stop("The two valid methods for returning ZCTA values are 'centroid' and 'intersect'. See documentation for details.")
   }
 
@@ -80,9 +80,9 @@ zi_list_zctas <- function(year, state, method){
 
   # subset based on method
   if (method == "centroid"){
-    sub <- dplyr::filter(reference_centroids, fips %in% statez == TRUE & year == yearz)
+    sub <- dplyr::filter(reference_centroids, fips %in% statez & year == yearz)
   } else if (method == "intersect"){
-    sub <- dplyr::filter(reference_intersects, fips %in% statez == TRUE & year == yearz)
+    sub <- dplyr::filter(reference_intersects, fips %in% statez & year == yearz)
   }
 
   sub <- sub$obj

--- a/R/zi_load_crosswalk.R
+++ b/R/zi_load_crosswalk.R
@@ -60,33 +60,33 @@ zi_load_crosswalk <- function(zip_source = "UDS", year, qtr = NULL, target = NUL
                               query = NULL, key = NULL){
 
   # check inputs
-  if (zip_source %in% c("UDS", "HUD") == FALSE){
+  if (!(zip_source %in% c("UDS", "HUD"))){
     stop("The 'zip_source' value provided is invalid. Please input either 'UDS' or 'HUD'.")
   }
 
-  if (is.numeric(year) == FALSE){
+  if (!is.numeric(year)){
     stop("The 'year' value provided is invalid. Please provide a numeric value for the requested year.")
   }
 
-  if (zip_source == "UDS" & year %in% c(2009:2022) == FALSE){
+  if (zip_source == "UDS" & !(year %in% c(2009:2022))){
     stop("The 'year' value provided is invalid for UDS data. Please provide a year between 2009 and 2022.")
   }
 
   if (zip_source == "HUD"){
 
-    if (year %in% c(2010:2024) == FALSE){
+    if (!(year %in% c(2010:2024))){
       stop("The 'year' value provided is invalid for HUD data. Please provide a year between 2010 and 2024.")
     }
 
-    if (qtr %in% c(1:4) == FALSE){
+    if (!(qtr %in% c(1:4))){
       stop("The 'qtr' value is required when 'zip_source' is 'HUD'. Please provide a value between 1 and 4.")
     }
 
-    if (target %in% c("TRACT", "COUNTY", "CBSA", "CBSADIV", "CD", "COUNTYSUB") == FALSE){
+    if (!(target %in% c("TRACT", "COUNTY", "CBSA", "CBSADIV", "CD", "COUNTYSUB"))){
       stop("The 'target' value is required when 'zip_source' is 'HUD'. Please provide a valid target value (see help file).")
     }
 
-    if (is.null(query) == TRUE){
+    if (is.null(query)){
       stop("The 'query' value is required when 'zip_source' is 'HUD'. Please provide a valid query value (see help file).")
     }
   }
@@ -135,7 +135,7 @@ zi_load_uds <- function(year) {
 
   # Remove military zip if 'zip_type' column exists
   if ("zip_type" %in% names(out)) {
-    out <- dplyr::filter(out, grepl("^M", zip_type) == FALSE)
+    out <- dplyr::filter(out, !grepl("^M", zip_type))
   }
 
   # Convert 'po_name' to title case if it exists
@@ -145,7 +145,7 @@ zi_load_uds <- function(year) {
 
   # Remove N/A zcta if 'zcta' column exists
   if ("zcta" %in% names(out)) {
-    out <- dplyr::filter(out, zcta %in% c("N/A", NA) == FALSE)
+    out <- dplyr::filter(out, !(zcta %in% c("N/A", NA)))
   }
 
   ## remove non-ZCTA geometries
@@ -160,13 +160,13 @@ zi_load_uds <- function(year) {
   # check validation
   valid_zip <- zi_validate(out$zip)
 
-  if (valid_zip == FALSE) {
+  if (!valid_zip) {
     warning("The 'zip' column failed initial validation. Inspect it closely and address issues found with 'zi_validate()' before using.")
   }
 
   valid_zcta <- zi_validate(out$zcta)
 
-  if (valid_zcta == FALSE) {
+  if (!valid_zcta) {
     warning("The 'ZCTA' column failed initial validation. Inspect it closely and address issues found with 'zi_validate()' before using.")
   }
 
@@ -177,7 +177,7 @@ zi_load_uds <- function(year) {
 
 zi_load_hud <- function(year, qtr, target, queries, key = NULL){
 
-  if (is.null(key) == TRUE){
+  if (is.null(key)){
     key <- Sys.getenv("hud_key")
   }
 
@@ -190,7 +190,7 @@ zi_load_hud <- function(year, qtr, target, queries, key = NULL){
   # Loop over queries using map_dfr
   result <- purrr::map_dfr(queries, function(query) {
 
-    if (year <= 2020 & query %in% c(datasets::state.abb, "VI", "PR", "ALL") == TRUE){
+    if (year <= 2020 & query %in% c(datasets::state.abb, "VI", "PR", "ALL")){
       stop("Queries with two letter state abbreviations or ALL are only available from the 1st quarter of 2021 onwards.")
     }
 
@@ -202,7 +202,7 @@ zi_load_hud <- function(year, qtr, target, queries, key = NULL){
       stop("COUNTYSUB data is available from the 2nd quarter of 2018 onwards.")
     }
 
-    if (query %in% c(datasets::state.abb, "VI", "PR", "ALL") == FALSE & is.numeric(query) == FALSE && nchar(as.character(query)) != 5){
+    if (!(query %in% c(datasets::state.abb, "VI", "PR", "ALL")) & !is.numeric(query) && nchar(as.character(query)) != 5){
       stop("The 'query' value provided is invalid. Please input a valid state abbreviation or zip code.")
     }
 

--- a/R/zi_load_labels.R
+++ b/R/zi_load_labels.R
@@ -62,7 +62,7 @@ zi_load_labels <- function(source = "UDS", type = "zip5", include_scf = FALSE,
       stop("The 'UDS' source only provides ZIP5 data, replace 'type' with 'zip5'.")
     }
 
-    if (is.numeric(vintage) == FALSE){
+    if (!is.numeric(vintage)){
       vintage_num <- as.numeric(vintage)
     } else {
       vintage_num <- vintage
@@ -72,7 +72,7 @@ zi_load_labels <- function(source = "UDS", type = "zip5", include_scf = FALSE,
       stop("The 'UDS' source only provides ZIP5 data between 2009 and 2022.")
     }
 
-    if (include_scf == TRUE){
+    if (include_scf){
       warning("The 'include_scf' argument only modifies the output of 'zip3' labels.")
     }
 
@@ -82,7 +82,7 @@ zi_load_labels <- function(source = "UDS", type = "zip5", include_scf = FALSE,
       stop("The 'USPS' source only provides ZIP3 data, replace 'type' with 'zip3'.")
     }
 
-    if (is.numeric(vintage) == TRUE){
+    if (is.numeric(vintage)){
       vintage_chr <- as.character(vintage)
     } else {
       vintage_chr <- vintage
@@ -148,7 +148,7 @@ zi_load_labels_usps <- function(type, include_scf, vintage){
     out <- dplyr::rename(out, label_area = destination_area, label_state = destination_state)
 
     ## optionally remove scf cols
-    if (include_scf == FALSE){
+    if (!include_scf){
       out <- subset(out, select = -c(scf_id, scf_name, scf_state))
     }
 

--- a/R/zi_prep_hud.R
+++ b/R/zi_prep_hud.R
@@ -36,15 +36,15 @@
 zi_prep_hud <- function(.data, by, return_max = TRUE){
 
   # check input data
-  if (missing(by) == TRUE){
+  if (missing(by)){
     stop("A value for 'by' value is missing and is required. Please input either 'residential', 'commercial', or 'total'.")
   }
 
-  if (by %in% c("residential", "commercial", "total") == FALSE){
+  if (!(by %in% c("residential", "commercial", "total"))){
     stop("The 'by' value provided is invalid. Please input either 'residential', 'commercial', or 'total'.")
   }
 
-  if (is.logical(return_max) == FALSE){
+  if (!is.logical(return_max)){
     stop("A logical value must be provided for the 'return_max' argument.")
   }
 
@@ -72,11 +72,11 @@ zi_prep_hud <- function(.data, by, return_max = TRUE){
   out <- dplyr::arrange(out, zip5, state, geoid)
   out <- dplyr::group_by(out, zip5, state)
 
-  if (return_max == TRUE){
+  if (return_max){
     out <- dplyr::arrange(out, geoid)
     out <- dplyr::filter(out, ratio == max(ratio, na.rm = TRUE))
     out <- dplyr::slice(out, 1)
-  } else if (return_max == FALSE){
+  } else if (!return_max){
     out <- dplyr::mutate(out,
                          max = ifelse(ratio == max(ratio, na.rm = TRUE),
                                       TRUE, FALSE)
@@ -86,7 +86,7 @@ zi_prep_hud <- function(.data, by, return_max = TRUE){
   out <- dplyr::ungroup(out)
 
   # subset on max and prep output
-  out <- dplyr::filter(out, is.na(state) == FALSE)
+  out <- dplyr::filter(out, !is.na(state))
 
   # return output
   return(out)

--- a/R/zi_validate.R
+++ b/R/zi_validate.R
@@ -52,24 +52,24 @@
 zi_validate <- function(x, style = "zcta5", verbose = FALSE){
 
   # check inputs
-  if (missing(x) == TRUE){
+  if (missing(x)){
     stop("Please provide a vector of data for validation.")
   }
 
-  if (is.data.frame(x) == TRUE){
+  if (is.data.frame(x)){
     stop("Please provide a vector of data, instead of a data frame, for validation.")
   }
 
-  if (style %in% c("zcta5", "zcta3") == FALSE){
+  if (!(style %in% c("zcta5", "zcta3"))){
     stop("The 'style' value provided is invalid. Please select either 'zcta5' or 'zcta3'.")
   }
 
-  if (is.logical(verbose) == FALSE){
+  if (!is.logical(verbose)){
     stop("The 'verbose' value provided is invalid. Please select either 'TRUE' or 'FALSE'.")
   }
 
   # ensure character
-  if (is.character(x) == FALSE){
+  if (!is.character(x)){
     chr_out <- FALSE
   } else {
     chr_out <- TRUE
@@ -134,9 +134,9 @@ zi_validate <- function(x, style = "zcta5", verbose = FALSE){
   }
 
   # create output
-  if (verbose == FALSE){
+  if (!verbose){
     out <- all(c(chr_out, len_out2, len_out3, num_out))
-  } else if (verbose == TRUE){
+  } else if (verbose){
 
     if (style == "zcta5"){
       length_prompt <- "No input values are over 5 characters long?"
@@ -206,30 +206,30 @@ zi_validate <- function(x, style = "zcta5", verbose = FALSE){
 zi_repair <- function(x, style = "zcta5"){
 
   # check inputs
-  if (missing(x) == TRUE){
+  if (missing(x)){
     stop("Please provide a vector of data for validation.")
   }
 
-  if (is.data.frame(x) == TRUE){
+  if (is.data.frame(x)){
     stop("Please provide a vector of data, instead of a data frame, for validation.")
   }
 
-  if (style %in% c("zcta5", "zcta3") == FALSE){
+  if (!(style %in% c("zcta5", "zcta3"))){
     stop("The 'style' value provided is invalid. Please select either 'zcta5' or 'zcta3'.")
   }
 
   # run validation
   valid <- zi_validate(x, style = style, verbose = TRUE)
 
-  if (all(valid$result) == FALSE){
+  if (!all(valid$result)){
 
     # ensure character
-    if (valid$result[1] == FALSE){
+    if (!valid$result[1]){
       x <- as.character(x)
     }
 
     # identify issue where length is too long
-    if (valid$result[3] == FALSE){
+    if (!valid$result[3]){
 
       if (style == "zcta5"){
         x <- ifelse(nchar(x) > 5, NA, x)
@@ -240,12 +240,12 @@ zi_repair <- function(x, style = "zcta5"){
     }
 
     # convert characters to NA
-    if (valid$result[4] == FALSE){
+    if (!valid$result[4]){
       x <- as.character(suppressWarnings(as.numeric(x)))
     }
 
     # ensure padding
-    if (valid$result[2] == FALSE){
+    if (!valid$result[2]){
 
       if (style == "zcta5"){
         x <- stringr::str_pad(x, 5, pad = "0")
@@ -256,7 +256,7 @@ zi_repair <- function(x, style = "zcta5"){
     }
 
     # returning warning
-    if (valid$result[3] == FALSE | valid$result[4] == FALSE){
+    if (!valid$result[3] | !valid$result[4]){
       warning("NAs introduced by coercion")
     }
 


### PR DESCRIPTION
## Summary

Removes all `== TRUE` and `== FALSE` anti-patterns from R source files, replacing them with idiomatic R style (`!x` for negation, bare conditions for truth checks).

## Implementation

- Mechanical replacement across 11 R/ files (~155 occurrences)
- `== TRUE` → bare condition
- `== FALSE` → `!` negation (with `!()` wrapping for `%in%` to preserve operator precedence)
- No functional changes to any logic paths

## Testing

- ✅ Zero remaining `== TRUE`/`== FALSE` in `R/`
- ✅ Package loads cleanly (`pkgload::load_all()`)
- ✅ 85/86 tests pass (1 pre-existing unrelated test failure: typo in expected error message)
- ✅ UAT sign-off confirmed by user during session

## Closes

- Closes #11

## Notes

- Also includes `.github/copilot-instructions.md` adding UAT gate for future R/ changes
- The single test failure in `test_zi_aggregate.R:52` is a pre-existing typo (`investgiate` vs `investigate`) unrelated to this PR
