### PR TITLE
feat: complete Epic A — Test Coverage & Quality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Remove `== TRUE` / `== FALSE` anti-patterns across all R/ sources (#11)
+- Remove deprecated `context()` calls from all test files; adopt testthat 3rd edition (#8)
 
 ### Added
 - EVGen workflow scaffolding vendored from pfizer-evgen/rwd-agent-skills
+- Tests for `zi_convert`, `zi_label`, `zi_load_labels`, `zi_load_labels_list`, `zi_prep_hud` (#7)
+- Complete placeholder tests in `test_zi_crosswalk.R` and `test_zi_get_demographics.R` (#18)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,6 +24,7 @@ License: Apache License (>= 2)
 URL: https://github.com/pfizer-opensource/zippeR
 Encoding: UTF-8
 LazyData: true
+Config/testthat/edition: 3
 RoxygenNote: 7.3.2
 Imports:
     cli,

--- a/tests/testthat/test_zi_aggregate.R
+++ b/tests/testthat/test_zi_aggregate.R
@@ -1,5 +1,3 @@
-context("test zi_aggregate function")
-
 # create test data ------------------------------------------------
 
 correct_year = 2010

--- a/tests/testthat/test_zi_convert.R
+++ b/tests/testthat/test_zi_convert.R
@@ -1,0 +1,65 @@
+# test zi_convert ------------------------------------------------
+
+# create test data ------------------------------------------------
+
+df_good <- data.frame(
+  id = c(1:3),
+  zip5 = c("63005", "63139", "63636")
+)
+
+df_bad_zip <- data.frame(
+  id = c(1:3),
+  zip5 = c("63005", "63139", "ham")
+)
+
+df_numeric <- data.frame(
+  id = c(1:3),
+  zip5 = c(63005, 63139, 63636)
+)
+
+# test errors ------------------------------------------------
+
+test_that("missing parameters trigger appropriate errors", {
+  expect_error(zi_convert(df_good),
+               "is required", fixed = TRUE)
+})
+
+test_that("incorrectly specified parameters trigger appropriate errors", {
+  expect_error(zi_convert(.data = "not_a_df", input_var = zip5),
+               "must be a data frame", fixed = TRUE)
+  expect_error(zi_convert(.data = df_good, input_var = nonexistent),
+               "was not found", fixed = TRUE)
+  expect_error(zi_convert(.data = df_bad_zip, input_var = zip5),
+               "are invalid", fixed = TRUE)
+})
+
+# test inputs ------------------------------------------------
+
+test_that("correctly specified functions execute without error", {
+  expect_no_error(zi_convert(.data = df_good, input_var = zip5))
+  expect_warning(zi_convert(.data = df_good, input_var = zip5, output_var = zip3),
+                 "already exists")
+})
+
+# test outputs ------------------------------------------------
+
+test_that("correctly specified functions produce expected classes", {
+  result <- zi_convert(.data = df_good, input_var = zip5)
+  expect_s3_class(result, "tbl_df")
+})
+
+test_that("conversion produces correct 3-digit values", {
+  result <- zi_convert(.data = df_good, input_var = zip5)
+  expect_equal(result$zip5, c("630", "631", "636"))
+})
+
+test_that("overwrite mode replaces column in place", {
+  result <- zi_convert(.data = df_good, input_var = zip5)
+  expect_equal(result$zip5, c("630", "631", "636"))
+})
+
+test_that("output_var overwrites existing column with warning", {
+  df_conflict <- data.frame(id = c(1:3), zip5 = c("63005", "63139", "63636"))
+  expect_warning(zi_convert(.data = df_conflict, input_var = zip5, output_var = zip3),
+                 "already exists", fixed = TRUE)
+})

--- a/tests/testthat/test_zi_crosswalk.R
+++ b/tests/testthat/test_zi_crosswalk.R
@@ -1,5 +1,3 @@
-context("test zi_crosswalk function")
-
 # create test data ------------------------------------------------
 
 df_data_bad <- data.frame(
@@ -33,3 +31,11 @@ test_that("correctly specified functions execute without error", {
 })
 
 # test outputs ------------------------------------------------
+
+test_that("correctly specified functions produce expected output", {
+  result <- zi_crosswalk(df_data_good, input_var = good_zip, zip_source = hud_dict, source_var = zip5, source_result = geoid)
+  expect_s3_class(result, "tbl_df")
+  expect_true("source_geoid" %in% names(result))
+  expect_equal(nrow(result), nrow(df_data_good))
+  expect_type(result$source_geoid, "character")
+})

--- a/tests/testthat/test_zi_get_demographics.R
+++ b/tests/testthat/test_zi_get_demographics.R
@@ -1,5 +1,3 @@
-context("test zi_get_demographics function")
-
 # create test data ------------------------------------------------
 
 correct_year = 2010
@@ -42,9 +40,9 @@ test_that("incorrectly specified parameters trigger appropriate errors", {
 
 # test inputs ------------------------------------------------
 
-# # can't get this to work
-# test_that("correctly specified functions execute without error", {
-#   expect_error(zi_get_demographics(year = 2011, survey = "acs1", variables = c(medincome = "B01003_001")), NA)
-# })
-
-# test outputs ------------------------------------------------
+test_that("correctly specified functions execute without error", {
+  skip_on_cran()
+  skip_if_offline()
+  skip_if(nchar(Sys.getenv("CENSUS_API_KEY")) == 0, "Census API key not available")
+  expect_no_error(zi_get_demographics(year = 2012, survey = "acs5", variables = c(pop = "B01003_001")))
+})

--- a/tests/testthat/test_zi_get_geometry.R
+++ b/tests/testthat/test_zi_get_geometry.R
@@ -1,5 +1,3 @@
-context("test zi_get_geometry function")
-
 # create test data ------------------------------------------------
 
 chr_year <- "2010"

--- a/tests/testthat/test_zi_label.R
+++ b/tests/testthat/test_zi_label.R
@@ -1,0 +1,77 @@
+# test zi_label ------------------------------------------------
+
+# create test data ------------------------------------------------
+
+df_zip5 <- data.frame(
+
+  id = c(1:3),
+  zip5 = c("63005", "63139", "63636")
+)
+
+df_zip3 <- data.frame(
+  id = c(1:3),
+  zip3 = c("630", "631", "636")
+)
+
+df_bad_zip <- data.frame(
+  id = c(1:3),
+  zip5 = c("63005", "63139", "ham")
+)
+
+# test errors ------------------------------------------------
+
+test_that("missing parameters trigger appropriate errors", {
+  expect_error(zi_label(df_zip5),
+               "is required", fixed = TRUE)
+})
+
+test_that("incorrectly specified parameters trigger appropriate errors", {
+  expect_error(zi_label(.data = "not_a_df", input_var = zip5),
+               "must be a data frame", fixed = TRUE)
+  expect_error(zi_label(.data = df_zip5, input_var = nonexistent),
+               "was not found", fixed = TRUE)
+  expect_error(zi_label(.data = df_bad_zip, input_var = zip5),
+               "are invalid", fixed = TRUE)
+  expect_error(zi_label(.data = df_zip5, input_var = zip5, label_source = "INVALID"),
+               "must be", fixed = TRUE)
+  expect_error(zi_label(.data = df_zip5, input_var = zip5, label_source = "UDS", type = "bad"),
+               "must be", fixed = TRUE)
+  expect_error(zi_label(.data = df_zip3, input_var = zip3, label_source = "UDS", type = "zip3"),
+               "must be", fixed = TRUE)
+  expect_error(zi_label(.data = df_zip5, input_var = zip5, label_source = "USPS", type = "zip5"),
+               "must be", fixed = TRUE)
+  expect_error(zi_label(.data = df_zip5, input_var = zip5, label_source = "UDS", vintage = 2000),
+               "must be between", fixed = TRUE)
+})
+
+test_that("custom dictionary requires source_var", {
+  custom_dict <- data.frame(zip5 = c("63005"), city = c("Chesterfield"))
+  expect_error(zi_label(df_zip5, input_var = zip5, label_source = custom_dict),
+               "is required", fixed = TRUE)
+})
+
+test_that("custom dictionary source_var must exist", {
+  custom_dict <- data.frame(zip5 = c("63005"), city = c("Chesterfield"))
+  expect_error(zi_label(df_zip5, input_var = zip5, label_source = custom_dict, source_var = bad_col),
+               "was not found", fixed = TRUE)
+})
+
+# test inputs with custom dictionary ------------------------------------------------
+
+test_that("custom dictionary workflow executes without error", {
+  mo_label <- zi_mo_usps
+  expect_no_error(
+    zi_label(df_zip3, input_var = zip3, label_source = mo_label, source_var = zip3, type = "zip3")
+  )
+})
+
+# test outputs with custom dictionary ------------------------------------------------
+
+test_that("custom dictionary produces expected output", {
+  mo_label <- zi_mo_usps
+  result <- zi_label(df_zip3, input_var = zip3, label_source = mo_label, source_var = zip3, type = "zip3")
+  expect_s3_class(result, "tbl_df")
+  expect_true("label_area" %in% names(result))
+  expect_true("label_state" %in% names(result))
+  expect_equal(nrow(result), 3)
+})

--- a/tests/testthat/test_zi_list_zctas.R
+++ b/tests/testthat/test_zi_list_zctas.R
@@ -1,5 +1,3 @@
-context("test zi_list_zctas function")
-
 # create test data ------------------------------------------------
 
 incorrect_year_str <- "2010"

--- a/tests/testthat/test_zi_load_crosswalk.R
+++ b/tests/testthat/test_zi_load_crosswalk.R
@@ -1,5 +1,3 @@
-context("test zi_load_crosswalk function")
-
 # test errors ------------------------------------------------
 
 test_that("incorrectly specified parameters trigger appropriate errors", {

--- a/tests/testthat/test_zi_load_labels.R
+++ b/tests/testthat/test_zi_load_labels.R
@@ -1,0 +1,23 @@
+# test zi_load_labels ------------------------------------------------
+
+# test errors ------------------------------------------------
+
+test_that("incorrectly specified parameters trigger appropriate errors", {
+  expect_error(zi_load_labels(source = "INVALID"),
+               "must be", fixed = TRUE)
+  expect_error(zi_load_labels(source = "UDS", type = "bad"),
+               "must be", fixed = TRUE)
+  expect_error(zi_load_labels(source = "UDS", type = "zip3"),
+               "must be", fixed = TRUE)
+  expect_error(zi_load_labels(source = "USPS", type = "zip5"),
+               "must be", fixed = TRUE)
+  expect_error(zi_load_labels(source = "UDS", vintage = 2000),
+               "must be between", fixed = TRUE)
+})
+
+test_that("include_scf with zip5 produces a warning", {
+  skip_on_cran()
+  skip_if_offline()
+  expect_warning(zi_load_labels(source = "UDS", type = "zip5", include_scf = TRUE, vintage = 2022),
+                 "include_scf", fixed = TRUE)
+})

--- a/tests/testthat/test_zi_load_labels_list.R
+++ b/tests/testthat/test_zi_load_labels_list.R
@@ -1,0 +1,29 @@
+# test zi_load_labels_list ------------------------------------------------
+
+# test errors ------------------------------------------------
+
+test_that("incorrectly specified parameters trigger appropriate errors", {
+  expect_error(zi_load_labels_list(type = "bad"),
+               "must be", fixed = TRUE)
+  expect_error(zi_load_labels_list(type = "zip5"),
+               "must be", fixed = TRUE)
+})
+
+# test inputs ------------------------------------------------
+
+test_that("correctly specified functions execute without error", {
+  skip_on_cran()
+  skip_if_offline()
+  expect_no_error(zi_load_labels_list(type = "zip3"))
+})
+
+# test outputs ------------------------------------------------
+
+test_that("correctly specified functions produce expected output", {
+  skip_on_cran()
+  skip_if_offline()
+  result <- zi_load_labels_list(type = "zip3")
+  expect_s3_class(result, "tbl_df")
+  expect_true("date" %in% names(result))
+  expect_true(nrow(result) > 0)
+})

--- a/tests/testthat/test_zi_prep_hud.R
+++ b/tests/testthat/test_zi_prep_hud.R
@@ -1,0 +1,54 @@
+# test zi_prep_hud ------------------------------------------------
+
+# create test data ------------------------------------------------
+
+mo_xwalk <- zi_mo_hud
+
+# test errors ------------------------------------------------
+
+test_that("missing parameters trigger appropriate errors", {
+  expect_error(zi_prep_hud(mo_xwalk),
+               "is required", fixed = TRUE)
+})
+
+test_that("incorrectly specified parameters trigger appropriate errors", {
+  expect_error(zi_prep_hud(mo_xwalk, by = "invalid"),
+               "must be", fixed = TRUE)
+  expect_error(zi_prep_hud(mo_xwalk, by = "residential", return_max = "yes"),
+               "must be", fixed = TRUE)
+})
+
+# test inputs ------------------------------------------------
+
+test_that("correctly specified functions execute without error", {
+  skip_on_cran()
+  expect_no_error(zi_prep_hud(mo_xwalk, by = "residential"))
+  expect_no_error(zi_prep_hud(mo_xwalk, by = "commercial"))
+  expect_no_error(zi_prep_hud(mo_xwalk, by = "total"))
+  expect_no_error(zi_prep_hud(mo_xwalk, by = "residential", return_max = FALSE))
+})
+
+# test outputs ------------------------------------------------
+
+test_that("correctly specified functions produce expected classes", {
+  skip_on_cran()
+  result <- zi_prep_hud(mo_xwalk, by = "residential")
+  expect_s3_class(result, "tbl_df")
+  expect_true("zip5" %in% names(result))
+  expect_true("geoid" %in% names(result))
+  expect_true("state" %in% names(result))
+  expect_true("ratio" %in% names(result))
+})
+
+test_that("return_max = TRUE returns one row per zip5-state combination", {
+  skip_on_cran()
+  result <- zi_prep_hud(mo_xwalk, by = "residential", return_max = TRUE)
+  counts <- table(paste(result$zip5, result$state))
+  expect_true(all(counts == 1))
+})
+
+test_that("return_max = FALSE includes max column", {
+  skip_on_cran()
+  result <- zi_prep_hud(mo_xwalk, by = "residential", return_max = FALSE)
+  expect_true("max" %in% names(result))
+})

--- a/tests/testthat/test_zi_repair.R
+++ b/tests/testthat/test_zi_repair.R
@@ -1,5 +1,3 @@
-context("test zi_repair function")
-
 # create test data ------------------------------------------------
 
 correct_zips_1 <- c("63088", "63108", "63139")

--- a/tests/testthat/test_zi_validate.R
+++ b/tests/testthat/test_zi_validate.R
@@ -1,5 +1,3 @@
-context("test zi_validate function")
-
 # create test data ------------------------------------------------
 
 correct_zips_1 <- c("63088", "63108", "63139")


### PR DESCRIPTION
## Summary

Completes all three remaining sub-issues of [Epic A] Test Coverage & Quality (#22):

- **#7** — Add tests for 5 untested exported functions
- **#8** — Remove deprecated testthat `context()` calls
- **#18** — Complete abandoned/placeholder tests

## Implementation

- 5 new test files: `test_zi_convert.R`, `test_zi_label.R`, `test_zi_load_labels.R`, `test_zi_load_labels_list.R`, `test_zi_prep_hud.R`
- Removed `context()` from all 8 existing test files
- Added `Config/testthat/edition: 3` to DESCRIPTION
- Completed output validation in `test_zi_crosswalk.R`
- Replaced commented-out test in `test_zi_get_demographics.R` with skip-guarded integration test

## Testing

All 143 tests pass locally (0 failures, 0 warnings, 0 skips).

## Closes

Closes #7, closes #8, closes #18

## Notes

- Discovered a bug in `zi_convert()` where `output_var` resolves to the input column name — filed as #33 (not fixed here; tests document current behavior).
- Network-dependent tests (`zi_load_labels_list`, `zi_get_demographics`) use `skip_on_cran()` / `skip_if_offline()` guards.
- No R/ source files were modified — only tests and DESCRIPTION.