### PR TITLE
feat: enable R package caching in lint and pkgdown CI workflows

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,6 +25,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          cache: TRUE
           extra-packages: any::lintr, local::.
           needs: lint
 

--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -14,7 +14,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -24,6 +24,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          cache: TRUE
           extra-packages: any::pkgdown, local::.
           needs: website
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Enable R package dependency caching in lint and pkgdown CI workflows; bump `actions/checkout` v2 → v4 in pkgdown (#32)
 - Remove `== TRUE` / `== FALSE` anti-patterns across all R/ sources (#11)
 - Remove deprecated `context()` calls from all test files; adopt testthat 3rd edition (#8)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -5,7 +5,7 @@ last_updated: "2026-05-28"
 
 ## Now (in progress)
 
-_No epics currently in flight._
+- **[Epic D] Package Infrastructure & CRAN Readiness** (#25) — 0/3 sub-issues closed + #32 CI caching
 
 ## Next (planned)
 


### PR DESCRIPTION
## Summary

Enables R package dependency caching in the `lint.yaml` and `pkgdown.yml` CI workflows by adding `cache: TRUE` to the `r-lib/actions/setup-r-dependencies@v2` step. Also bumps `actions/checkout` from v2 to v4 in pkgdown.

## Implementation

- Added `cache: TRUE` to `setup-r-dependencies` in `lint.yaml`
- Added `cache: TRUE` to `setup-r-dependencies` in `pkgdown.yml`
- Bumped `actions/checkout@v2` → `@v4` in `pkgdown.yml`
- Moved Epic D to Now horizon on roadmap

## Testing

- CI will validate on this PR (cold cache run)
- Subsequent runs will use cached dependencies, reducing execution time

## Closes

- Closes #32

## Notes

- `R-CMD-check.yaml` already had `cache: TRUE` — no change needed there
- Cache key is automatically derived from OS + R version + DESCRIPTION hash by the action