### PR TITLE
feat: clean up DESCRIPTION metadata for CRAN readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Set minimum R version to 4.1 in DESCRIPTION (#21)
+- Remove base packages (`datasets`, `stats`) from Imports (#10)
+- Add minimum version constraints for all dependencies (#15)
 - Remove `== TRUE` / `== FALSE` anti-patterns across all R/ sources (#11)
 - Remove deprecated `context()` calls from all test files; adopt testthat 3rd edition (#8)
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Description: Provides a set of functions for working with American postal codes,
    which are known as ZIP Codes. These include accessing ZIP Code to ZIP Code 
    Tabulation Area (ZCTA) crosswalks, retrieving demographic data for ZCTAs, and 
    tabulating demographic data for three-digit ZCTAs.
-Depends: R (>= 3.5)
+Depends: R (>= 4.1)
 License: Apache License (>= 2)
 URL: https://github.com/pfizer-opensource/zippeR
 Encoding: UTF-8
@@ -27,24 +27,22 @@ LazyData: true
 Config/testthat/edition: 3
 RoxygenNote: 7.3.2
 Imports:
-    cli,
-    datasets,
-    dplyr,
-    httr,
-    jsonlite,
-    purrr,
-    readr,
-    sf,
-    spatstat.univar,
-    stats,
-    stringr,
-    tibble,
-    tidycensus,
-    tidyr,
-    tigris
+    cli (>= 3.0.0),
+    dplyr (>= 1.0.0),
+    httr (>= 1.4.0),
+    jsonlite (>= 1.7.0),
+    purrr (>= 0.3.0),
+    readr (>= 2.0.0),
+    sf (>= 1.0-0),
+    spatstat.univar (>= 0.1-0),
+    stringr (>= 1.4.0),
+    tibble (>= 3.0.0),
+    tidycensus (>= 1.0),
+    tidyr (>= 1.0.0),
+    tigris (>= 1.0)
 Suggests:
     knitr,
     lintr,
     rmarkdown,
-    testthat
+    testthat (>= 3.0.0)
 VignetteBuilder: knitr


### PR DESCRIPTION
## Summary

Cleans up DESCRIPTION metadata as part of [Epic D] Package Infrastructure & CRAN Readiness (#25). Three sub-issues addressed in a single commit since they all touch the same file.

## Implementation

1. **Set minimum R version to 4.1** (#21) — enables native pipe and lambda shorthand; aligns with CI matrix (oldrel-4 ≥ R 4.2 in 2026).
2. **Remove base packages from Imports** (#10) — removed `datasets` and `stats`; both are base packages always available. Code continues using `datasets::state.abb` and `stats::weighted.mean` via `::` notation (no Imports entry needed for base packages).
3. **Add minimum version constraints** (#15) — all 13 Imports now have minimum versions matching the features actually used, plus `testthat (>= 3.0.0)` in Suggests.

## Testing

- `R CMD check`: 0 errors, 0 warnings, 1 pre-existing NOTE (`.lintr` hidden file)
- `testthat::test_local()`: all tests pass

## Closes

Closes #21, closes #10, closes #15

## Notes

- No R/ source files were modified — this is metadata-only
- Also closed #32 (CI caching) separately as it was already in place (`cache: TRUE` in `R-CMD-check.yaml`)
- Epic D (#25) will be fully resolved once this PR merges
