### PR TITLE
feat: cache system dependencies in CI to improve execution time

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -42,13 +42,51 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - name: Install macOS specific dependencies for sf
+      # Cache system dependencies to avoid reinstalling GDAL/PROJ/GEOS each run.
+      # Key includes OS, workflow file hash, and a weekly rolling date segment
+      # so caches refresh periodically but hit on most runs.
+      - name: Get week number for cache rotation
+        id: week
+        run: echo "week=$(date +%V)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Linux system dependencies
+        id: cache-linux-syslibs
+        if: runner.os == 'Linux'
+        uses: actions/cache@v4
+        with:
+          path: |
+            /usr/lib/x86_64-linux-gnu/libgdal*
+            /usr/lib/x86_64-linux-gnu/libproj*
+            /usr/lib/x86_64-linux-gnu/libgeos*
+            /usr/lib/x86_64-linux-gnu/libudunits*
+            /usr/include/gdal
+            /usr/include/proj
+            /usr/include/geos
+          key: syslibs-linux-${{ hashFiles('.github/workflows/R-CMD-check.yaml') }}-${{ steps.week.outputs.week }}
+          restore-keys: |
+            syslibs-linux-
+
+      - name: Cache macOS Homebrew dependencies
+        id: cache-macos-syslibs
         if: runner.os == 'macOS'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Caches/Homebrew
+            /opt/homebrew/Cellar/gdal
+            /opt/homebrew/Cellar/proj
+            /opt/homebrew/Cellar/udunits
+          key: syslibs-macos-${{ hashFiles('.github/workflows/R-CMD-check.yaml') }}-${{ steps.week.outputs.week }}
+          restore-keys: |
+            syslibs-macos-
+
+      - name: Install macOS specific dependencies for sf
+        if: runner.os == 'macOS' && steps.cache-macos-syslibs.outputs.cache-hit != 'true'
         run: brew install udunits gdal proj
 
       - name: Install Linux specific dependencies for sf
-        if: runner.os == 'Linux'
-        run: sudo apt-get install libgdal-dev libproj-dev libgeos-dev libudunits2-dev
+        if: runner.os == 'Linux' && steps.cache-linux-syslibs.outputs.cache-hit != 'true'
+        run: sudo apt-get install -y --no-install-recommends libgdal-dev libproj-dev libgeos-dev libudunits2-dev
 
       - name: Install Dependencies
         uses: r-lib/actions/setup-r-dependencies@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove base packages (`datasets`, `stats`) from Imports (#10)
 - Add minimum version constraints for all dependencies (#15)
 - Enable R package dependency caching in lint and pkgdown CI workflows; bump `actions/checkout` v2 → v4 in pkgdown (#32)
+- Cache system dependencies (GDAL, PROJ, GEOS, udunits) on Linux and macOS in CI; install steps run only on cache miss (#32)
 - Remove `== TRUE` / `== FALSE` anti-patterns across all R/ sources (#11)
 - Remove deprecated `context()` calls from all test files; adopt testthat 3rd edition (#8)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -17,5 +17,6 @@ _No epics in the backlog._
 
 ## Recently Shipped
 
+- **[Epic B] Code Style & Error Handling** (#23) — closed 2026-05-28
 - **[Epic D] Package Infrastructure & CRAN Readiness** (#25) — closed 2026-05-28
 - **[Epic A] Test Coverage & Quality** (#22) — closed 2026-05-28


### PR DESCRIPTION
## Summary

Adds `actions/cache@v4` steps for system dependencies (GDAL, PROJ, GEOS, udunits) on both Linux and macOS in the R-CMD-check workflow. Install steps now run only on cache miss, reducing warm-cache CI time significantly.

## Implementation

- Week-number step (`date +%V`) for periodic cache rotation
- Linux cache: `/usr/lib/x86_64-linux-gnu/lib{gdal,proj,geos,udunits}*` + headers
- macOS cache: `~/Library/Caches/Homebrew` + `/opt/homebrew/Cellar/{gdal,proj,udunits}`
- Cache key: `syslibs-<os>-<workflow-hash>-<week>`
- Conditional `brew install` / `apt-get install` on cache miss only
- Added `--no-install-recommends` flag to Linux apt-get

## Testing

- Cold cache: this PR triggers the first CI run (will install deps and populate cache)
- Warm cache: subsequent pushes or re-runs will validate cache hits
- Pattern validated in `deprivateR` repo

## Closes

- Closes #32

## Notes

- R package caching was already enabled via `r-lib/actions/setup-r-dependencies@v2` — this PR addresses the remaining gap (system-level libraries)
- No R/ source changes; no UAT required