### PR TITLE
docs: document NULL returns and remove manual @usage tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Document NULL return values in `@return` tags for `zi_get_demographics()`, `zi_get_geometry()`, and `zi_aggregate()` (#12)
+- Remove all manual `@usage` roxygen2 tags; usage sections now auto-generated (#19)
 - Set minimum R version to 4.1 in DESCRIPTION (#21)
 - Remove base packages (`datasets`, `stats`) from Imports (#10)
 - Add minimum version constraints for all dependencies (#15)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,6 @@ Encoding: UTF-8
 LazyData: true
 Language: en-US
 Config/testthat/edition: 3
-RoxygenNote: 7.3.2
 Imports:
     cli (>= 3.0.0),
     dplyr (>= 1.0.0),
@@ -49,3 +48,4 @@ Suggests:
     spelling,
     testthat (>= 3.0.0)
 VignetteBuilder: knitr
+Config/roxygen2/version: 8.0.0

--- a/R/zi_aggregate.R
+++ b/R/zi_aggregate.R
@@ -4,9 +4,6 @@
 #'    areas, which are considerably larger. These regions are sometimes used in
 #'    American health care contexts for publishing geographic identifiers.
 #'
-#' @usage zi_aggregate(.data, year, extensive = NULL, intensive = NULL,
-#'     intensive_method = "mean", survey, output = "tidy", zcta = NULL,
-#'     key = NULL)
 #'
 #' @param .data A tidy set of demographic data containing one or more variables
 #'     that should be aggregated to three-digit ZCTAs. This data frame or tibble
@@ -55,7 +52,8 @@
 #'     written to \code{.Renviron} by using \code{Sys.getenv("CENSUS_API_KEY")}.
 #'
 #' @return A tibble containing all aggregated data requested in either
-#'     \code{"tidy"} or \code{"wide"} format.
+#'     \code{"tidy"} or \code{"wide"} format, or \code{NULL} if population
+#'     weight data cannot be downloaded from the Census Bureau API.
 #'
 #' @examples
 #' # load sample demographic data

--- a/R/zi_convert.R
+++ b/R/zi_convert.R
@@ -5,7 +5,6 @@
 #'     and corresponds to the sectional center facility (SCF) that processes mail
 #'     for a region.
 #'
-#' @usage zi_convert(.data, input_var, output_var)
 #'
 #' @param .data A data frame containing a column of five-digit ZIP Codes.
 #' @param input_var A character scalar specifying the column name with the five-digit

--- a/R/zi_crosswalk.R
+++ b/R/zi_crosswalk.R
@@ -4,9 +4,6 @@
 #'     a crosswalk file that will append ZCTAs. This is an important step because
 #'     not all ZIP Codes have the same five digits as their enclosing ZCTA.
 #'
-#' @usage zi_crosswalk(.data, input_var, zip_source = "UDS", source_var,
-#'     source_result, year = NULL, qtr = NULL, target = NULL, query = NULL,
-#'     by = NULL, return_max = NULL, key = NULL, return = "id")
 #'
 #' @param .data An "input object" that is data.frame or tibble that contains
 #'     ZIP Codes to be crosswalked.

--- a/R/zi_get_demographics.R
+++ b/R/zi_get_demographics.R
@@ -4,8 +4,6 @@
 #'     Tabulation Areas (ZCTAs), which are rough approximations of many (but not
 #'     all) USPS ZIP codes.
 #'
-#' @usage zi_get_demographics(year, variables = NULL, table = NULL,
-#'     survey, output = "tidy", zcta = NULL, key = NULL)
 #'
 #' @param year A four-digit numeric scalar for year. \code{zippeR} currently
 #'     supports data for from 2010 to 2022. Different \code{survey} products
@@ -39,7 +37,8 @@
 #'     written to \code{.Renviron} by using \code{Sys.getenv("CENSUS_API_KEY")}.
 #'
 #' @return A tibble containing all demographic data requested in either
-#'     \code{"tidy"} or \code{"wide"} format.
+#'     \code{"tidy"} or \code{"wide"} format, or \code{NULL} if the Census
+#'     Bureau API call fails.
 #'
 #' @examples
 #' \donttest{

--- a/R/zi_get_geometry.R
+++ b/R/zi_get_geometry.R
@@ -7,10 +7,6 @@
 #'     argument, and the processing power of your computer (if you select
 #'     specific counties).
 #'
-#' @usage zi_get_geometry (year, style = "zcta5", return = "id", class = "sf",
-#'     state = NULL, county = NULL, territory = NULL, cb = FALSE,
-#'     starts_with = NULL, includes = NULL, excludes = NULL, method,
-#'     shift_geo = FALSE)
 #'
 #' @param year A four-digit numeric scalar for year. \code{zippeR} currently
 #'     supports data between 2010 and 2023
@@ -95,9 +91,11 @@
 #'     will be used as a base before identifying ZCTAs within counties using
 #'     either the \code{"intersect"} or \code{"centroid"} method described above.
 #'
-#' @return A \code{sf} object with ZCTAs matching the parameters specified above:
-#'     either a nationwide file, a specific state or states, or a specific
-#'     county or counties.
+#' @return A \code{sf} object (or \code{tibble} if \code{class = "tibble"})
+#'     with ZCTAs matching the parameters specified above: either a nationwide
+#'     file, a specific state or states, or a specific county or counties.
+#'     Returns \code{NULL} if the Census Bureau download fails or if state
+#'     validation yields no matching ZCTAs.
 #'
 #' @examples
 #' \donttest{

--- a/R/zi_label.R
+++ b/R/zi_label.R
@@ -6,8 +6,6 @@
 #'    also optionally returns data on Sectional Center Facilities (SCFs) for
 #'    three-digit ZIP Codes.
 #'
-#' @usage zi_label(.data, input_var, label_source = "UDS", source_var,
-#'     type = "zip5", include_scf = FALSE, vintage = 2022)
 #'
 #' @param .data An "input object" that is data.frame or tibble that contains
 #'     ZIP Codes to be crosswalked.

--- a/R/zi_list_zctas.R
+++ b/R/zi_list_zctas.R
@@ -4,7 +4,6 @@
 #'     in and around states, depending on the method selected. The two methods
 #'     included described in Details below.
 #'
-#' @usage zi_list_zctas(year, state, method)
 #'
 #' @param year A four-digit numeric scalar for year. \code{zippeR} currently
 #'     supports data between 2010 and 2021.

--- a/R/zi_load_crosswalk.R
+++ b/R/zi_load_crosswalk.R
@@ -10,8 +10,6 @@
 #'     which provide similar functionality for converting ZIP Codes to a variety
 #'     of geographies including counties.
 #'
-#' @usage zi_load_crosswalk(zip_source = "UDS", year, qtr = NULL, target = NULL,
-#'     query = NULL, key = NULL)
 #'
 #' @param zip_source Required character scalar; specifies the source of ZIP Code
 #'     crosswalk data. This can be one of either \code{"UDS"} (default) or

--- a/R/zi_load_labels.R
+++ b/R/zi_load_labels.R
@@ -3,8 +3,6 @@
 #' @description This function loads a specific label data set that can be used to
 #'     label five or three-digit ZIP codes in a data frame.
 #'
-#' @usage zi_load_labels(source = "UDS", type = "zip5", include_scf = FALSE,
-#'     vintage = 2022)
 #'
 #' @param source A required character scalar; specifies the source of the label
 #'     data. The only supported sources are \code{'UDS'} (default) and

--- a/R/zi_load_labels_list.R
+++ b/R/zi_load_labels_list.R
@@ -4,7 +4,6 @@
 #'    be used to label ZIP Codes. Currently, only three-digit ZIP Codes are
 #'    supported.
 #'
-#' @usage zi_load_labels_list(type = "zip3")
 #'
 #' @param type A character scalar specifying the type of label data to load. The
 #'   only supported type is  \code{'zip3'} (three-digit ZIP Codes).

--- a/R/zi_mo_hud.R
+++ b/R/zi_mo_hud.R
@@ -5,7 +5,6 @@
 #'
 #' @docType data
 #'
-#' @usage data(zi_mo_hud)
 #'
 #' @format A data frame with 1749 rows and 8 variables:
 #' \describe{

--- a/R/zi_mo_pop.R
+++ b/R/zi_mo_pop.R
@@ -7,7 +7,6 @@
 #'
 #' @docType data
 #'
-#' @usage data(zi_mo_pop)
 #'
 #' @format A data frame with 2664 rows and 4 variables:
 #' \describe{

--- a/R/zi_mo_usps.R
+++ b/R/zi_mo_usps.R
@@ -5,7 +5,6 @@
 #'
 #' @docType data
 #'
-#' @usage data(zi_mo_usps)
 #'
 #' @format A data frame with 37 rows and 3 variables:
 #' \describe{

--- a/R/zi_mo_zcta3.R
+++ b/R/zi_mo_zcta3.R
@@ -6,7 +6,6 @@
 #'
 #' @docType data
 #'
-#' @usage data(zi_mo_zcta3)
 #'
 #' @format A data frame with 31 rows and 2 variables:
 #' \describe{

--- a/R/zi_prep_hud.R
+++ b/R/zi_prep_hud.R
@@ -4,7 +4,6 @@
 #'     additional processing to be used in the \code{zi_crosswalk()} function.
 #'     This function prepares the HUD data for use in joins.
 #'
-#' @usage zi_prep_hud(.data, by, return_max = TRUE)
 #'
 #' @param .data The output from \code{zi_load_crosswalk()} with HUD data.
 #' @param by Character scalar; the column name to use for identifying the best

--- a/man/zi_aggregate.Rd
+++ b/man/zi_aggregate.Rd
@@ -4,9 +4,17 @@
 \alias{zi_aggregate}
 \title{Aggregate ZCTAs to Three-digit ZCTAs}
 \usage{
-zi_aggregate(.data, year, extensive = NULL, intensive = NULL,
-    intensive_method = "mean", survey, output = "tidy", zcta = NULL,
-    key = NULL)
+zi_aggregate(
+  .data,
+  year,
+  extensive = NULL,
+  intensive = NULL,
+  intensive_method = "mean",
+  survey,
+  output = "tidy",
+  zcta = NULL,
+  key = NULL
+)
 }
 \arguments{
 \item{.data}{A tidy set of demographic data containing one or more variables
@@ -65,7 +73,8 @@ written to \code{.Renviron} by using \code{Sys.getenv("CENSUS_API_KEY")}.}
 }
 \value{
 A tibble containing all aggregated data requested in either
-    \code{"tidy"} or \code{"wide"} format.
+    \code{"tidy"} or \code{"wide"} format, or \code{NULL} if population
+    weight data cannot be downloaded from the Census Bureau API.
 }
 \description{
 This function takes input ZCTA data and aggregates it to three-digit

--- a/man/zi_crosswalk.Rd
+++ b/man/zi_crosswalk.Rd
@@ -4,9 +4,21 @@
 \alias{zi_crosswalk}
 \title{Crosswalk ZIP Codes with UDS, HUD, or a Custom Dictionary}
 \usage{
-zi_crosswalk(.data, input_var, zip_source = "UDS", source_var,
-    source_result, year = NULL, qtr = NULL, target = NULL, query = NULL,
-    by = NULL, return_max = NULL, key = NULL, return = "id")
+zi_crosswalk(
+  .data,
+  input_var,
+  zip_source = "UDS",
+  source_var,
+  source_result,
+  year = NULL,
+  qtr = NULL,
+  target = NULL,
+  query = NULL,
+  by = NULL,
+  return_max = NULL,
+  key = NULL,
+  return = "id"
+)
 }
 \arguments{
 \item{.data}{An "input object" that is data.frame or tibble that contains

--- a/man/zi_get_demographics.Rd
+++ b/man/zi_get_demographics.Rd
@@ -4,8 +4,15 @@
 \alias{zi_get_demographics}
 \title{Download Demographic Data for Five-digit ZCTAs}
 \usage{
-zi_get_demographics(year, variables = NULL, table = NULL,
-    survey, output = "tidy", zcta = NULL, key = NULL)
+zi_get_demographics(
+  year,
+  variables = NULL,
+  table = NULL,
+  survey,
+  output = "tidy",
+  zcta = NULL,
+  key = NULL
+)
 }
 \arguments{
 \item{year}{A four-digit numeric scalar for year. \code{zippeR} currently
@@ -47,7 +54,8 @@ written to \code{.Renviron} by using \code{Sys.getenv("CENSUS_API_KEY")}.}
 }
 \value{
 A tibble containing all demographic data requested in either
-    \code{"tidy"} or \code{"wide"} format.
+    \code{"tidy"} or \code{"wide"} format, or \code{NULL} if the Census
+    Bureau API call fails.
 }
 \description{
 This function returns demographic data for five-digit ZIP Code

--- a/man/zi_get_geometry.Rd
+++ b/man/zi_get_geometry.Rd
@@ -4,10 +4,21 @@
 \alias{zi_get_geometry}
 \title{Download and Optionally Geoprocess ZCTAs}
 \usage{
-zi_get_geometry (year, style = "zcta5", return = "id", class = "sf",
-    state = NULL, county = NULL, territory = NULL, cb = FALSE,
-    starts_with = NULL, includes = NULL, excludes = NULL, method,
-    shift_geo = FALSE)
+zi_get_geometry(
+  year,
+  style = "zcta5",
+  return = "id",
+  class = "sf",
+  state = NULL,
+  county = NULL,
+  territory = NULL,
+  cb = FALSE,
+  starts_with = NULL,
+  includes = NULL,
+  excludes = NULL,
+  method = NULL,
+  shift_geo = FALSE
+)
 }
 \arguments{
 \item{year}{A four-digit numeric scalar for year. \code{zippeR} currently
@@ -80,9 +91,11 @@ states are not listed for the \code{state} argument. It does not apply
 if \code{class = "tibble"}.}
 }
 \value{
-A \code{sf} object with ZCTAs matching the parameters specified above:
-    either a nationwide file, a specific state or states, or a specific
-    county or counties.
+A \code{sf} object (or \code{tibble} if \code{class = "tibble"})
+    with ZCTAs matching the parameters specified above: either a nationwide
+    file, a specific state or states, or a specific county or counties.
+    Returns \code{NULL} if the Census Bureau download fails or if state
+    validation yields no matching ZCTAs.
 }
 \description{
 This function returns geometric data for ZIP Code Tabulation

--- a/man/zi_label.Rd
+++ b/man/zi_label.Rd
@@ -4,8 +4,15 @@
 \alias{zi_label}
 \title{Label ZIP Codes with Contextual Data}
 \usage{
-zi_label(.data, input_var, label_source = "UDS", source_var,
-    type = "zip5", include_scf = FALSE, vintage = 2022)
+zi_label(
+  .data,
+  input_var,
+  label_source = "UDS",
+  source_var,
+  type = "zip5",
+  include_scf = FALSE,
+  vintage = 2022
+)
 }
 \arguments{
 \item{.data}{An "input object" that is data.frame or tibble that contains

--- a/man/zi_load_crosswalk.Rd
+++ b/man/zi_load_crosswalk.Rd
@@ -4,8 +4,14 @@
 \alias{zi_load_crosswalk}
 \title{Load Crosswalk Files}
 \usage{
-zi_load_crosswalk(zip_source = "UDS", year, qtr = NULL, target = NULL,
-    query = NULL, key = NULL)
+zi_load_crosswalk(
+  zip_source = "UDS",
+  year,
+  qtr = NULL,
+  target = NULL,
+  query = NULL,
+  key = NULL
+)
 }
 \arguments{
 \item{zip_source}{Required character scalar; specifies the source of ZIP Code

--- a/man/zi_load_labels.Rd
+++ b/man/zi_load_labels.Rd
@@ -4,8 +4,12 @@
 \alias{zi_load_labels}
 \title{Load Label Data}
 \usage{
-zi_load_labels(source = "UDS", type = "zip5", include_scf = FALSE,
-    vintage = 2022)
+zi_load_labels(
+  source = "UDS",
+  type = "zip5",
+  include_scf = FALSE,
+  vintage = 2022
+)
 }
 \arguments{
 \item{source}{A required character scalar; specifies the source of the label

--- a/man/zi_mo_hud.Rd
+++ b/man/zi_mo_hud.Rd
@@ -26,7 +26,7 @@ U.S. Department of Housing and Urban Development's ZIP Code crosswalk
     files
 }
 \usage{
-data(zi_mo_hud)
+zi_mo_hud
 }
 \description{
 A tibble containing the HUD ZIP Code to County Crosswalk file

--- a/man/zi_mo_pop.Rd
+++ b/man/zi_mo_pop.Rd
@@ -18,7 +18,7 @@ A data frame with 2664 rows and 4 variables:
 U.S. Census Bureau American Community Survey
 }
 \usage{
-data(zi_mo_pop)
+zi_mo_pop
 }
 \description{
 A tibble containing the total population

--- a/man/zi_mo_usps.Rd
+++ b/man/zi_mo_usps.Rd
@@ -16,7 +16,7 @@ A data frame with 37 rows and 3 variables:
 U.S. Postal Service Facility Access and Shipment Tracking (FAST) Database
 }
 \usage{
-data(zi_mo_usps)
+zi_mo_usps
 }
 \description{
 A tibble containing the USPS Three-digit ZIP Code labels for

--- a/man/zi_mo_zcta3.Rd
+++ b/man/zi_mo_zcta3.Rd
@@ -15,7 +15,7 @@ A data frame with 31 rows and 2 variables:
 U.S. Census Bureau's TIGER/Line database
 }
 \usage{
-data(zi_mo_zcta3)
+zi_mo_zcta3
 }
 \description{
 A simple features data set containing the geometric data


### PR DESCRIPTION
<!-- pr-skill-managed-start -->
## Summary

Documents NULL return values in `@return` roxygen2 tags and removes all manual `@usage` tags, letting roxygen2 auto-generate usage sections from function signatures.

## Implementation

**Issue #12 — Document NULL return values:**
- Added NULL documentation to `@return` for `zi_get_demographics()`, `zi_get_geometry()`, and `zi_aggregate()`
- These functions return NULL when Census Bureau API/FTP calls fail or state validation yields no matching ZCTAs

**Issue #19 — Remove manual @usage tags:**
- Removed all 15 manual `@usage` roxygen2 tags across R/ source files
- roxygen2 now auto-generates usage from function signatures (eliminating drift risk)
- Cleaned up residual double-blank roxygen comment lines

## Testing

- `devtools::document()` regenerates all man/ pages without warnings
- All 143 existing tests pass (`testthat::test_local(".")`)
- Verified auto-generated `\usage{}` sections in man/ pages are correct

## Closes

- Closes #12
- Closes #19

## Notes

⚠️ **UAT Required** — This PR modifies files in `R/`. Per repo conventions, human acceptance testing is required before merge. Changes are documentation-only (roxygen2 comments) with no logic modifications.
<!-- pr-skill-managed-end -->
