### PR TITLE
docs: populate docs/ hub with package-relevant content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove deprecated `context()` calls from all test files; adopt testthat 3rd edition (#8)
 
 ### Added
+- Data provenance README in `inst/build-data/` documenting build scripts, execution order, prerequisites, and outputs (#20)
+- Package architecture overview, domain glossary, objectives, and updated roadmap in `docs/` hub (#26)
 - `BugReports` field in DESCRIPTION pointing to GitHub Issues (#14)
 - Spelling check CI workflow with `inst/WORDLIST` for domain-specific terms (#17)
 - `spelling` package added to Suggests (#17)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,22 +1,110 @@
 ---
-last_updated: "2026-05-26"
+last_updated: "2026-05-29"
 ---
 # Architecture — zippeR
 
 ## Overview
 
-zippeR is an R package providing tools for working with ZIP Codes, ZCTAs (ZIP Code Tabulation Areas), and 3-digit ZCTAs.
+zippeR is an R package that provides a unified interface for working with
+United States ZIP Codes, ZIP Code Tabulation Areas (ZCTAs), and 3-digit ZCTAs.
+It handles the complexity of mapping between postal delivery zones (ZIP Codes)
+and Census Bureau geographic units (ZCTAs), including crosswalking, demographic
+retrieval, spatial operations, and aggregation to 3-digit regions.
 
 ## Key Abstractions
 
-- **ZIP Codes** — USPS postal delivery zones
-- **ZCTAs** — Census Bureau geographic approximations of ZIP Code areas
-- **3-digit ZCTAs** — Aggregated ZCTA regions by first 3 digits
+- **ZIP Code** — A 5-digit USPS postal delivery route identifier. Not a
+  geographic area; has no official boundary.
+- **ZCTA** — ZIP Code Tabulation Area. A Census Bureau polygon that
+  approximates the geographic extent of one or more ZIP Codes.
+- **3-digit ZCTA** — An aggregated region formed by dissolving ZCTAs that share
+  the same first 3 digits. Used in US healthcare contexts for geographic
+  de-identification.
+- **Crosswalk** — A lookup table that maps ZIP Codes to ZCTAs (or counties),
+  since the mapping is not 1:1. Sources include HUD and UDS.
 
 ## Package Structure
 
-Standard R package layout (`R/`, `man/`, `tests/`, `data/`, `vignettes/`).
+```
+R/
+├── zi_get_geometry.R       # Download & geoprocess ZCTA shapefiles
+├── zi_get_demographics.R   # Retrieve ACS demographic data for ZCTAs
+├── zi_aggregate.R          # Aggregate ZCTA data to 3-digit ZCTAs
+├── zi_load_crosswalk.R     # Load ZIP-to-ZCTA/county crosswalk files
+├── zi_crosswalk.R          # Apply a crosswalk to user data
+├── zi_convert.R            # Convert 5-digit ZIPs to 3-digit ZIPs
+├── zi_load_labels.R        # Load city/area labels for ZIP codes
+├── zi_load_labels_list.R   # List available label vintages
+├── zi_label.R              # Append label data to a data frame
+├── zi_list_zctas.R         # List ZCTA GEOIDs for a state
+├── zi_validate.R           # Validate ZIP/ZCTA input vectors
+├── zi_prep_hud.R           # Prepare HUD crosswalk data
+├── zi_utils.R              # Internal utilities
+├── zi_globals.R            # Global variable declarations
+├── sysdata.rda             # Internal data (ZCTA vectors, reference tables)
+└── zi_mo_*.R               # Example dataset documentation
+```
 
-## Dependencies
+## Data Flow
 
-See `DESCRIPTION` for the full dependency list.
+The typical user workflow follows one of two paths:
+
+### Path 1: ZIP Code → ZCTA → Demographics
+
+```
+User ZIP data
+  → zi_validate()          validate input
+  → zi_crosswalk()         map ZIPs to ZCTAs via HUD/UDS crosswalk
+  → zi_get_demographics()  pull ACS data for matched ZCTAs
+  → zi_aggregate()         (optional) roll up to 3-digit ZCTAs
+```
+
+### Path 2: Spatial Analysis
+
+```
+zi_get_geometry()          download ZCTA shapefiles (state-filtered)
+  → zi_get_demographics()  join demographic data
+  → zi_aggregate()         (optional) aggregate to 3-digit regions
+```
+
+### Labeling (auxiliary)
+
+```
+zi_load_labels()           load city/area names for ZIP codes
+  → zi_label()             append labels to user data
+```
+
+## Internal Data (`R/sysdata.rda`)
+
+The package ships pre-computed lookup vectors that map ZCTAs to states for every
+Census vintage (2010–2023). These are built by `inst/build-data/build_vectors.R`
+using two spatial methods:
+
+- **Intersects** — ZCTAs that geometrically overlap a state boundary
+- **Centroids** — ZCTAs whose centroid falls within a state
+
+A reference table tracks which vintage to use for each state×year combination,
+accounting for year-over-year ZCTA boundary changes.
+
+## External Dependencies
+
+| Package | Role |
+|---------|------|
+| `tidycensus` | Census API access (ACS demographics) |
+| `tigris` | TIGER/Line shapefiles (ZCTA & state boundaries) |
+| `sf` | Spatial operations (intersection, centroid, transform) |
+| `dplyr` | Data manipulation |
+| `readr` | CSV/TSV parsing (crosswalk files) |
+| `rlang` | Tidy evaluation, error signaling |
+| `utils` | Base R utilities (download, unzip) |
+
+## Design Decisions
+
+- **No bundled shapefiles** — ZCTA geometries are downloaded on demand via
+  `tigris` to keep package size small and data current.
+- **Pre-computed state vectors** — Spatial intersection is expensive; results
+  are cached in `sysdata.rda` so `zi_get_geometry(state=)` is fast.
+- **Multiple crosswalk sources** — HUD and UDS crosswalks serve different use
+  cases; the package supports both plus user-supplied custom dictionaries.
+- **Vintage-aware** — All functions accept a `year` parameter and route to the
+  correct underlying data/API vintage.

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -1,5 +1,5 @@
 ---
-last_updated: "2026-05-26"
+last_updated: "2026-05-29"
 ---
 # Glossary — zippeR
 
@@ -15,8 +15,46 @@ Terms shared across all EVGen repos. See vendored ADRs for authoritative definit
 
 ## Domain Terms
 
+### Geographic & Postal Concepts
+
 | Term | Definition |
 |---|---|
-| ZIP Code | A USPS postal delivery zone identifier (5-digit) |
-| ZCTA | ZIP Code Tabulation Area — Census Bureau geographic approximation |
-| 3-digit ZCTA | Aggregated geographic region sharing the first 3 digits of a ZCTA |
+| ZIP Code | A 5-digit identifier assigned by USPS to mail delivery routes. Not a geographic area — has no official boundary polygon. |
+| ZIP3 Code | The first 3 digits of a ZIP Code, corresponding to a Sectional Center Facility (SCF) service area. |
+| ZCTA | ZIP Code Tabulation Area — a Census Bureau geographic polygon that approximates the area served by one or more ZIP Codes. Built from census blocks. |
+| 3-digit ZCTA | An aggregated geographic region formed by dissolving all ZCTAs sharing the same first 3 digits. Used in healthcare for geographic de-identification. |
+| GEOID | Geographic Identifier — the Census Bureau's unique code for a geographic entity (e.g., a 5-digit string for a ZCTA). |
+| Crosswalk | A lookup table mapping between two identifier systems (e.g., ZIP Code → ZCTA, or ZIP Code → County FIPS). |
+| FIPS Code | Federal Information Processing Standards code — numeric identifiers for states (2-digit) and counties (5-digit). |
+| SCF | Sectional Center Facility — a USPS mail processing plant that handles mail for a group of ZIP Codes sharing the same first 3 digits. |
+
+### Data Sources & Agencies
+
+| Term | Definition |
+|---|---|
+| Census Bureau | U.S. Census Bureau — source of ZCTA boundaries, ACS demographic data, and TIGER/Line shapefiles. |
+| USPS | United States Postal Service — assigns and maintains ZIP Codes. |
+| HUD | U.S. Department of Housing and Urban Development — publishes quarterly ZIP-to-ZCTA/county crosswalk files. |
+| UDS | Uniform Data System — health center crosswalk maintained by HRSA mapping ZIP Codes to ZCTAs. |
+| ACS | American Community Survey — an ongoing Census Bureau survey providing demographic, social, economic, and housing data. Published in 1-year and 5-year estimates. |
+| TIGER/Line | Topologically Integrated Geographic Encoding and Referencing — the Census Bureau's spatial data product containing boundary shapefiles. |
+
+### R Ecosystem
+
+| Term | Definition |
+|---|---|
+| tidycensus | R package providing an interface to the Census Bureau's API for retrieving ACS and decennial data. |
+| tigris | R package for downloading TIGER/Line shapefiles (states, counties, ZCTAs, etc.) directly into R as `sf` objects. |
+| sf | Simple Features — the R package and standard for representing spatial vector data (points, lines, polygons). |
+| roxygen2 | R documentation system that generates `.Rd` man pages from inline comments in source files. |
+
+### Package-Specific Terms
+
+| Term | Definition |
+|---|---|
+| Vintage | A specific year of geographic or demographic data (e.g., 2022 ACS 5-year, 2023 TIGER/Line boundaries). |
+| Intersect method | Spatial filtering that selects ZCTAs whose geometry overlaps a state boundary — may include ZCTAs spanning multiple states. |
+| Centroid method | Spatial filtering that selects ZCTAs whose geometric center (centroid) falls within a state boundary — assigns each ZCTA to exactly one state. |
+| Extensive variable | A variable that scales with population size and is summed during aggregation (e.g., total population). |
+| Intensive variable | A variable that does not scale with size and requires weighted averaging during aggregation (e.g., median income). |
+| sysdata.rda | Internal package data file containing pre-computed ZCTA-to-state lookup vectors for all supported vintages. |

--- a/docs/OBJECTIVES.md
+++ b/docs/OBJECTIVES.md
@@ -1,11 +1,40 @@
 ---
-last_updated: "2026-05-26"
+last_updated: "2026-05-29"
 ---
 # Objectives — zippeR
 
 ## Active Objectives
 
-_No active objectives defined yet._
+### O1: CRAN-ready package quality
+
+Ensure zippeR meets CRAN submission standards for documentation, testing, and
+package structure.
+
+**Key Results:**
+
+- KR1: All exported functions have complete roxygen2 documentation (`@param`,
+  `@return`, `@examples`) — _achieved (Epic C)_
+- KR2: R CMD check passes with 0 errors, 0 warnings, 0 notes — _in progress_
+- KR3: Test coverage ≥ 80% for all exported functions — _achieved (Epic A)_
+- KR4: `DESCRIPTION` fields complete (URL, BugReports, Language) — _achieved
+  (Epic D)_
+
+_Last check-in: 2026-05-29_
+
+### O2: Comprehensive geographic coverage
+
+Support the full range of Census Bureau ZCTA vintages and crosswalk sources
+relevant to health services research.
+
+**Key Results:**
+
+- KR1: ZCTA geometries available for all TIGER/Line vintages 2010–2023 —
+  _achieved_
+- KR2: HUD and UDS crosswalk loading supported — _achieved_
+- KR3: 3-digit ZCTA aggregation supports both extensive and intensive variables
+  — _achieved_
+
+_Last check-in: 2026-05-29_
 
 ## Retired Objectives
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,7 +9,8 @@ last_updated: "2026-05-29"
 
 ## Next (planned)
 
-_No epics queued._
+- **[Epic E] Code & Test Quality Audit** (#48) — Systematic audit of test coverage and source code quality; 0/2 sub-issues closed
+- **[Epic F] New Features & Enhancements** (#49) — New user-facing features and data coverage expansion; 0/1 sub-issues closed
 
 ## Later (aspirational)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,11 +1,11 @@
 ---
-last_updated: "2026-05-28"
+last_updated: "2026-05-29"
 ---
 # Roadmap — zippeR
 
 ## Now (in progress)
 
-_No epics in progress._
+- **[Epic C] Documentation Improvements** (#24) — 5/7 sub-issues closed; remaining: #20 (data provenance README), #26 (docs hub content)
 
 ## Next (planned)
 


### PR DESCRIPTION
## Summary

Replaces placeholder scaffolding in `docs/` with substantive package-specific content across four files.

## Implementation

- **ARCHITECTURE.md**: Module map of all R/ source files, two data-flow diagrams (crosswalk path & spatial path), internal data documentation, dependency table, and design decisions.
- **GLOSSARY.md**: 20+ terms across four categories — geographic/postal concepts, data sources & agencies, R ecosystem, and package-specific terms (extensive/intensive variables, vintage, intersect vs centroid methods).
- **OBJECTIVES.md**: Two active objectives with key results — CRAN readiness (4 KRs) and geographic coverage (3 KRs).
- **ROADMAP.md**: Updated to reflect Epic C in progress (was incorrectly showing no active epics).

## Testing

Documentation-only change. No code or test modifications.

## Closes

Closes #26

## Notes

Part of [Epic C] Documentation Improvements (#24). With #20 and #26 complete, all 7 sub-issues of Epic C are closed.