### PR TITLE
fix: use substitute(output_var) in zi_convert output_var branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Fix `zi_convert()` using `substitute(input_var)` instead of `substitute(output_var)` when `output_var` is specified, which caused the input column to be overwritten instead of creating a new output column (#33)
 - Replace live Census API calls in `test_zi_aggregate.R` with local fixtures so `R CMD check` passes on CRAN without a Census API key (#6)
 - Normalize non-standard column names in 2015 UDS crosswalk (`zcta_use` → `zcta`, etc.) so `zi_load_crosswalk(zip_source = "UDS", year = 2015)` no longer errors (#5)
 

--- a/R/zi_convert.R
+++ b/R/zi_convert.R
@@ -61,7 +61,7 @@ zi_convert <- function(.data, input_var, output_var){
   }
 
   if (!missing(output_var)){
-    output_varQN <- as.character(substitute(input_var))
+    output_varQN <- as.character(substitute(output_var))
 
     if (output_varQN %in% names(.data)){
       cli::cli_warn(c(

--- a/tests/testthat/test_zi_convert.R
+++ b/tests/testthat/test_zi_convert.R
@@ -37,8 +37,7 @@ test_that("incorrectly specified parameters trigger appropriate errors", {
 
 test_that("correctly specified functions execute without error", {
   expect_no_error(zi_convert(.data = df_good, input_var = zip5))
-  expect_warning(zi_convert(.data = df_good, input_var = zip5, output_var = zip3),
-                 "already exists")
+  expect_no_error(zi_convert(.data = df_good, input_var = zip5, output_var = zip3))
 })
 
 # test outputs ------------------------------------------------
@@ -58,8 +57,15 @@ test_that("overwrite mode replaces column in place", {
   expect_equal(result$zip5, c("630", "631", "636"))
 })
 
+test_that("output_var creates a new column with the specified name", {
+  result <- zi_convert(.data = df_good, input_var = zip5, output_var = zip3)
+  expect_true("zip3" %in% names(result))
+  expect_equal(result$zip3, c("630", "631", "636"))
+  expect_equal(result$zip5, c("63005", "63139", "63636"))
+})
+
 test_that("output_var overwrites existing column with warning", {
-  df_conflict <- data.frame(id = c(1:3), zip5 = c("63005", "63139", "63636"))
+  df_conflict <- data.frame(id = c(1:3), zip5 = c("63005", "63139", "63636"), zip3 = c("a", "b", "c"))
   expect_warning(zi_convert(.data = df_conflict, input_var = zip5, output_var = zip3),
                  "already exists", fixed = TRUE)
 })


### PR DESCRIPTION
## Summary

Fixes a bug in `zi_convert()` where specifying `output_var` still overwrote the input column instead of creating a new column with the requested name.

## Implementation

Line 64 of `R/zi_convert.R` used `substitute(input_var)` to derive `output_varQN` — this should have been `substitute(output_var)`. One-character fix.

## Testing

- Updated existing tests that documented the buggy behavior
- Added new test verifying `output_var` creates a distinct column while preserving the original input column
- Conflict test now properly sets up a pre-existing output column to trigger the warning
- All 160 tests pass

## Closes

Closes #33

## Notes

⚠️ **UAT required**: This PR modifies `R/zi_convert.R`. Per repo convention, changes to R/ scripts require user acceptance testing before merge.
