### PR TITLE
fix: resolve 6 high-priority bugs from Epic E audit (Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Source code quality analysis report (`docs/audits/2026-05-29-source-code-quality.md`) with 34 findings across 18 source files (#44)
 
 ### Fixed
+- Fix `zi_load_labels_list()` filter comparing `type` column to itself instead of the function argument (#52)
+- Fix `zi_load_labels()` USPS vintage filter using wrong column name (`vintage` → `date`) (#53)
+- Fix `zi_get_geometry()` county download failure path referencing undefined variable; now returns NULL gracefully (#54)
+- Add territory FIPS code normalization so numeric codes (60, 66, 69, 72, 78) are accepted as documented (#54)
+- Fix `zi_aggregate()` intensive weighting producing cartesian expansion by including GEOID in weights join (#55)
+- Add `intensive_method` validation with informative error message (#55)
+- Fix `zi_aggregate()` `output = "wide"` for decennial Census data which lacks `estimate`/`moe` columns (#55)
+- Fix `zi_load_crosswalk()` COUNTYSUB branch using wrong internal string (`COUNTY_SUB` → `COUNTYSUB`) (#56)
+- Fix `zi_repair()` stripping leading zeros via numeric coercion; now uses digit-only regex (#57)
 - Fix `zi_convert()` using `substitute(input_var)` instead of `substitute(output_var)` when `output_var` is specified, which caused the input column to be overwritten instead of creating a new output column (#33)
 - Replace live Census API calls in `test_zi_aggregate.R` with local fixtures so `R CMD check` passes on CRAN without a Census API key (#6)
 - Normalize non-standard column names in 2015 UDS crosswalk (`zcta_use` → `zcta`, etc.) so `zi_load_crosswalk(zip_source = "UDS", year = 2015)` no longer errors (#5)

--- a/R/zi_aggregate.R
+++ b/R/zi_aggregate.R
@@ -144,6 +144,13 @@ zi_aggregate <- function(.data, year, extensive = NULL, intensive = NULL,
     ))
   }
 
+  if (!intensive_method %in% c("mean", "median")){
+    cli::cli_abort(c(
+      "{.arg intensive_method} must be {.val mean} or {.val median}.",
+      "i" = "You provided {.val {intensive_method}}."
+    ))
+  }
+
   if (!inherits(.data, what = "data.frame")){
     cli::cli_abort("{.arg .data} must be a data frame or data frame-like object.")
   }
@@ -300,13 +307,19 @@ zi_aggregate <- function(.data, year, extensive = NULL, intensive = NULL,
     # optionally pivot
     if (output == "wide"){
 
-      ## prep names
-      out <- dplyr::rename(out, "E" = "estimate", "M" = "moe")
+      if (survey %in% c("sf1", "sf3")){
+        ## pivot decennial (single value column)
+        out <- tidyr::pivot_wider(out, id_cols = "ZCTA3", names_from = "variable",
+                                  values_from = "value")
+      } else {
+        ## prep names
+        out <- dplyr::rename(out, "E" = "estimate", "M" = "moe")
 
-      ## pivot
-      out <- tidyr::pivot_wider(out, id_cols = "ZCTA3", names_from = "variable",
-                                names_glue = "{variable}{.value}",
-                                values_from = c("E", "M"))
+        ## pivot
+        out <- tidyr::pivot_wider(out, id_cols = "ZCTA3", names_from = "variable",
+                                  names_glue = "{variable}{.value}",
+                                  values_from = c("E", "M"))
+      }
 
       ## re-order names alphabetically
       wide_names <- names(out)
@@ -344,10 +357,10 @@ zi_census_extensive <- function(.data){
 zi_census_intensive <- function(.data, weights, method){
 
   # global variables
-  ZCTA3 = variable = value = weight = NULL
+  ZCTA3 = GEOID = variable = value = weight = NULL
 
   ## join
-  .data <- dplyr::left_join(.data, weights, by = "ZCTA3")
+  .data <- dplyr::left_join(.data, weights, by = c("ZCTA3", "GEOID"))
 
   ## group_by
   .data <- dplyr::group_by(.data, ZCTA3, variable)
@@ -360,6 +373,11 @@ zi_census_intensive <- function(.data, weights, method){
       .data,
       value = spatstat.univar::weighted.median(value, weight)
     )
+  } else {
+    cli::cli_abort(c(
+      "{.arg intensive_method} must be {.val mean} or {.val median}.",
+      "i" = "You provided {.val {method}}."
+    ))
   }
 
   ## return output
@@ -395,7 +413,7 @@ zi_census_weights <- function(year, key){
     out <- dplyr::mutate(out, weight = value / total_pop)
 
     ## subset
-    out <- dplyr::select(out, ZCTA3, weight)
+    out <- dplyr::select(out, ZCTA3, GEOID, weight)
   }
 
   ## return output
@@ -430,10 +448,10 @@ zi_acs_extensive <- function(.data){
 zi_acs_intensive <- function(.data, weights, method){
 
   # global variables
-  ZCTA3 = variable = estimate = weight = moe = NULL
+  ZCTA3 = GEOID = variable = estimate = weight = moe = NULL
 
   ## join
-  .data <- dplyr::left_join(.data, weights, by = "ZCTA3")
+  .data <- dplyr::left_join(.data, weights, by = c("ZCTA3", "GEOID"))
 
   ## group_by
   .data <- dplyr::group_by(.data, ZCTA3, variable)
@@ -449,6 +467,11 @@ zi_acs_intensive <- function(.data, weights, method){
       estimate = spatstat.univar::weighted.median(estimate, weight),
       moe = spatstat.univar::weighted.median(moe, weight)
     )
+  } else {
+    cli::cli_abort(c(
+      "{.arg intensive_method} must be {.val mean} or {.val median}.",
+      "i" = "You provided {.val {method}}."
+    ))
   }
 
   ## return output
@@ -485,7 +508,7 @@ zi_acs_weights <- function(year, survey, key){
     out <- dplyr::mutate(out, weight = estimate / total_pop)
 
     ## subset
-    out <- dplyr::select(out, ZCTA3, weight)
+    out <- dplyr::select(out, ZCTA3, GEOID, weight)
   }
 
   ## return output

--- a/R/zi_get_geometry.R
+++ b/R/zi_get_geometry.R
@@ -209,12 +209,21 @@ zi_get_geometry <- function(year, style = "zcta5", return = "id", class = "sf",
   }
 
   ## validate counties
-  if (!is.null(territory) & !any(territory %in% c("AS", "GU", "MP", "PR", "VI"))){
-    cli::cli_abort(c(
-      "{.arg territory} contains an invalid value.",
-      "i" = "Use one or more of {.val AS}, {.val GU}, {.val MP}, {.val PR}, or {.val VI}, or their equivalent FIPS codes."
-    ))
+  if (!is.null(territory)){
+    ## normalize FIPS codes to abbreviations
+    territory_fips <- c("60" = "AS", "66" = "GU", "69" = "MP", "72" = "PR", "78" = "VI")
+    territory <- sapply(territory, function(t) {
+      t_str <- as.character(t)
+      if (t_str %in% names(territory_fips)) territory_fips[[t_str]] else t
+    }, USE.NAMES = FALSE)
+
+    if (!all(territory %in% c("AS", "GU", "MP", "PR", "VI"))){
+      cli::cli_abort(c(
+        "{.arg territory} contains an invalid value.",
+        "i" = "Use one or more of {.val AS}, {.val GU}, {.val MP}, {.val PR}, or {.val VI}, or their equivalent FIPS codes."
+      ))
     }
+  }
 
   if (!is.null(starts_with)){
     valid <- zi_validate_starts(starts_with)
@@ -457,6 +466,8 @@ zi_process_county <- function(cb, state, county, year, zcta, method, style){
     } else if (style == "zcta3"){
       out <- intersect$ZCTA3
     }
+  } else {
+    out <- NULL
   }
 
   # return output

--- a/R/zi_load_crosswalk.R
+++ b/R/zi_load_crosswalk.R
@@ -266,7 +266,7 @@ zi_load_hud <- function(year, qtr, target, queries, key = NULL){
       type <- "?type=4&query="
     } else if (target == "CD"){
       type <- "?type=5&query="
-    } else if (target == "COUNTY_SUB"){
+    } else if (target == "COUNTYSUB"){
       type <- "?type=11&query="
     }
 

--- a/R/zi_load_labels.R
+++ b/R/zi_load_labels.R
@@ -100,7 +100,7 @@ zi_load_labels <- function(source = "UDS", type = "zip5", include_scf = FALSE,
 
     labels_list <- zi_load_labels_list(type = "zip3")
 
-    result <- subset(labels_list, vintage == vintage_chr)
+    result <- subset(labels_list, date == vintage_chr)
 
     if (nrow(result) != 1){
       cli::cli_abort(c(

--- a/R/zi_load_labels_list.R
+++ b/R/zi_load_labels_list.R
@@ -31,7 +31,8 @@ zi_load_labels_list <- function(type = "zip3"){
   labels_list <- utils::read.csv(file = "https://raw.githubusercontent.com/chris-prener/usps-zip-ref/main/data/meta.csv")
 
   ## subset
-  out <- subset(labels_list, type == type)
+  type_val <- type
+  out <- subset(labels_list, type == type_val)
 
   ## convert to tibble
   out <- tibble::as_tibble(out)

--- a/R/zi_validate.R
+++ b/R/zi_validate.R
@@ -248,9 +248,9 @@ zi_repair <- function(x, style = "zcta5"){
 
     }
 
-    # convert characters to NA
+    # convert characters to NA (only for values that aren't purely digits)
     if (!valid$result[4]){
-      x <- as.character(suppressWarnings(as.numeric(x)))
+      x <- ifelse(grepl("^[0-9]+$", x), x, NA_character_)
     }
 
     # ensure padding


### PR DESCRIPTION
<!-- pr-skill-managed-start -->
## Summary

Resolves all 6 high-priority bugs identified in the Epic E code quality audit (#48). These are correctness bugs that produce silently wrong results or runtime crashes.

## Implementation

| Issue | File | Fix |
|-------|------|-----|
| #52 | `zi_load_labels_list.R` | Filter compared column to itself; introduced local variable |
| #53 | `zi_load_labels.R` | USPS vintage filter used wrong column name (`vintage` → `date`) |
| #54 | `zi_get_geometry.R` | County download failure returned undefined var; added NULL fallback + territory FIPS normalization |
| #55 | `zi_aggregate.R` | Weights join lacked GEOID causing cartesian expansion; added `intensive_method` validation; fixed wide pivot for decennial |
| #56 | `zi_load_crosswalk.R` | Internal string `COUNTY_SUB` never matched validated `COUNTYSUB` |
| #57 | `zi_validate.R` | `zi_repair()` stripped leading zeros via numeric roundtrip; replaced with digit-only regex |

## Testing

- Full test suite passes (`testthat::test_local()` — 0 failures)
- Package loads without error (`devtools::load_all()`)
- One pre-existing deprecation warning from tidyselect (unrelated)

## Closes

Closes #52, closes #53, closes #54, closes #55, closes #56, closes #57

## Notes

- **⚠️ UAT Required**: This PR modifies 6 files in `R/`. Human acceptance testing required before merge per repo standards.
- Part of [Epic E] #48 — Phase 1 (high-priority bug fixes)
- Code review gate: CLEAN (one informational note — defensive else-clauses in internal intensive functions are unreachable but acceptable as defense-in-depth)
<!-- pr-skill-managed-end -->