### PR TITLE
test: add coverage for HUD crosswalk/loading paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Test coverage gap analysis report (`docs/audits/2026-05-29-test-coverage-gaps.md`) mapping all 13 exported and 18 internal functions to coverage status (#43)
 - Source code quality analysis report (`docs/audits/2026-05-29-source-code-quality.md`) with 34 findings across 18 source files (#44)
+- Test coverage for HUD crosswalk/loading paths: input validation for `zi_load_crosswalk()`, `zi_crosswalk()`, and internal `zi_load_hud()` helper; end-to-end custom dictionary tests (#58)
 
 ### Fixed
 - Fix `zi_load_labels_list()` filter comparing `type` column to itself instead of the function argument (#52)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,6 +46,7 @@ Suggests:
     lintr,
     rmarkdown,
     spelling,
-    testthat (>= 3.0.0)
+    testthat (>= 3.0.0),
+    withr
 VignetteBuilder: knitr
 Config/roxygen2/version: 8.0.0

--- a/tests/testthat/test_zi_crosswalk.R
+++ b/tests/testthat/test_zi_crosswalk.R
@@ -23,6 +23,116 @@ test_that("invalid data trigger appropriate errors", {
 
 # test errors ------------------------------------------------
 
+test_that("invalid zip_source triggers appropriate error", {
+  expect_error(
+    zi_crosswalk(df_data_good, input_var = good_zip, zip_source = "INVALID"),
+    "`zip_source` must be", fixed = TRUE
+  )
+})
+
+test_that("non-data-frame .data triggers appropriate error", {
+  expect_error(
+    zi_crosswalk("not a data frame", input_var = good_zip, zip_source = "UDS", year = 2020),
+    "must be a data frame"
+  )
+})
+
+test_that("missing input_var triggers appropriate error", {
+  expect_error(
+    zi_crosswalk(df_data_good, zip_source = "UDS", year = 2020),
+    "`input_var` is required", fixed = TRUE
+  )
+})
+
+test_that("input_var not found in .data triggers appropriate error", {
+  expect_error(
+    zi_crosswalk(df_data_good, input_var = nonexistent_col, zip_source = "UDS", year = 2020),
+    "was not found in", fixed = TRUE
+  )
+})
+
+test_that("invalid return value triggers appropriate error", {
+  expect_error(
+    zi_crosswalk(df_data_good, input_var = good_zip, zip_source = hud_dict,
+                 source_var = zip5, source_result = geoid, return = "invalid"),
+    "`return` must be", fixed = TRUE
+  )
+})
+
+# test HUD API workflow validation ------------------------------------------------
+
+test_that("HUD workflow requires year as numeric", {
+  expect_error(
+    zi_crosswalk(df_data_good, input_var = good_zip, zip_source = "HUD",
+                 year = "2023", qtr = 1, target = "COUNTY", query = "MO",
+                 by = "residential", return_max = TRUE),
+    "`year` must be numeric", fixed = TRUE
+  )
+})
+
+test_that("HUD workflow validates year range", {
+  expect_error(
+    zi_crosswalk(df_data_good, input_var = good_zip, zip_source = "HUD",
+                 year = 2009, qtr = 1, target = "COUNTY", query = "MO",
+                 by = "residential", return_max = TRUE),
+    "`year` must be between", fixed = TRUE
+  )
+})
+
+test_that("HUD workflow validates quarter", {
+  expect_error(
+    zi_crosswalk(df_data_good, input_var = good_zip, zip_source = "HUD",
+                 year = 2023, qtr = 5, target = "COUNTY", query = "MO",
+                 by = "residential", return_max = TRUE),
+    "`qtr` must be between", fixed = TRUE
+  )
+})
+
+test_that("HUD workflow validates target", {
+  expect_error(
+    zi_crosswalk(df_data_good, input_var = good_zip, zip_source = "HUD",
+                 year = 2023, qtr = 1, target = "INVALID", query = "MO",
+                 by = "residential", return_max = TRUE),
+    "`target` is invalid", fixed = TRUE
+  )
+})
+
+test_that("HUD workflow requires query", {
+  expect_error(
+    zi_crosswalk(df_data_good, input_var = good_zip, zip_source = "HUD",
+                 year = 2023, qtr = 1, target = "COUNTY", query = NULL,
+                 by = "residential", return_max = TRUE),
+    "`query` is required", fixed = TRUE
+  )
+})
+
+test_that("HUD workflow requires by parameter", {
+  expect_error(
+    zi_crosswalk(df_data_good, input_var = good_zip, zip_source = "HUD",
+                 year = 2023, qtr = 1, target = "COUNTY", query = "MO",
+                 by = NULL, return_max = TRUE),
+    "`by` is required", fixed = TRUE
+  )
+})
+
+test_that("HUD workflow validates by parameter values", {
+  expect_error(
+    zi_crosswalk(df_data_good, input_var = good_zip, zip_source = "HUD",
+                 year = 2023, qtr = 1, target = "COUNTY", query = "MO",
+                 by = "invalid", return_max = TRUE),
+    "`by` must be", fixed = TRUE
+  )
+})
+
+test_that("HUD workflow validates return_max as logical", {
+  expect_error(
+    zi_crosswalk(df_data_good, input_var = good_zip, zip_source = "HUD",
+                 year = 2023, qtr = 1, target = "COUNTY", query = "MO",
+                 by = "residential", return_max = "yes"),
+    "`return_max` must be", fixed = TRUE
+  )
+})
+
 
 # test inputs ------------------------------------------------
 
@@ -38,4 +148,47 @@ test_that("correctly specified functions produce expected output", {
   expect_true("source_geoid" %in% names(result))
   expect_equal(nrow(result), nrow(df_data_good))
   expect_type(result$source_geoid, "character")
+})
+
+test_that("return = 'all' appends full dictionary columns", {
+  result <- zi_crosswalk(df_data_good, input_var = good_zip, zip_source = hud_dict,
+                         source_var = zip5, source_result = geoid, return = "all")
+  expect_s3_class(result, "tbl_df")
+  expect_true(any(grepl("^source_", names(result))))
+  expect_true(ncol(result) > ncol(df_data_good) + 1)
+})
+
+# test HUD end-to-end via custom dictionary ------------------------------------------------
+
+test_that("zi_crosswalk with zi_prep_hud (commercial) produces expected output", {
+  hud_commercial <- zi_prep_hud(zi_mo_hud, by = "commercial")
+  result <- zi_crosswalk(df_data_good, input_var = good_zip,
+                         zip_source = hud_commercial, source_var = zip5, source_result = geoid)
+  expect_s3_class(result, "tbl_df")
+  expect_true("source_geoid" %in% names(result))
+  expect_equal(nrow(result), nrow(df_data_good))
+})
+
+test_that("zi_crosswalk with zi_prep_hud (total) produces expected output", {
+  hud_total <- zi_prep_hud(zi_mo_hud, by = "total")
+  result <- zi_crosswalk(df_data_good, input_var = good_zip,
+                         zip_source = hud_total, source_var = zip5, source_result = geoid)
+  expect_s3_class(result, "tbl_df")
+  expect_true("source_geoid" %in% names(result))
+})
+
+test_that("zi_crosswalk with return_max = FALSE produces multiple rows for boundary ZIPs", {
+  # Use a ZIP that crosses county boundaries (63005 maps to multiple GEOIDs)
+  df_boundary <- data.frame(
+    id = 1L,
+    zip5 = "63005"
+  )
+  hud_all <- zi_prep_hud(zi_mo_hud, by = "residential", return_max = FALSE)
+  result <- zi_crosswalk(df_boundary, input_var = zip5,
+                         zip_source = hud_all, source_var = zip5, source_result = geoid)
+  expect_s3_class(result, "tbl_df")
+  expect_true("source_geoid" %in% names(result))
+  # With return_max = FALSE, a boundary ZIP should produce multiple rows
+
+  expect_gt(nrow(result), 1)
 })

--- a/tests/testthat/test_zi_load_crosswalk.R
+++ b/tests/testthat/test_zi_load_crosswalk.R
@@ -1,9 +1,86 @@
 # test errors ------------------------------------------------
 
 test_that("incorrectly specified parameters trigger appropriate errors", {
+
   expect_error(zi_load_crosswalk(zip_source = "ham", year = 2022),
                "`zip_source` must be", fixed = TRUE)
 
+})
+
+test_that("non-numeric year triggers appropriate error", {
+  expect_error(zi_load_crosswalk(zip_source = "UDS", year = "2020"),
+               "`year` must be numeric", fixed = TRUE)
+})
+
+# test HUD input validation ------------------------------------------------
+
+test_that("HUD year out of range triggers appropriate error", {
+  expect_error(
+    zi_load_crosswalk(zip_source = "HUD", year = 2009, qtr = 1, target = "COUNTY", query = "63139"),
+    "`year` must be between", fixed = TRUE
+  )
+  expect_error(
+    zi_load_crosswalk(zip_source = "HUD", year = 2025, qtr = 1, target = "COUNTY", query = "63139"),
+    "`year` must be between", fixed = TRUE
+  )
+})
+
+test_that("HUD invalid quarter triggers appropriate error", {
+  expect_error(
+    zi_load_crosswalk(zip_source = "HUD", year = 2023, qtr = 5, target = "COUNTY", query = "63139"),
+    "`qtr` must be between", fixed = TRUE
+  )
+  expect_error(
+    zi_load_crosswalk(zip_source = "HUD", year = 2023, qtr = 0, target = "COUNTY", query = "63139"),
+    "`qtr` must be between", fixed = TRUE
+  )
+})
+
+test_that("HUD invalid target triggers appropriate error", {
+  expect_error(
+    zi_load_crosswalk(zip_source = "HUD", year = 2023, qtr = 1, target = "INVALID", query = "63139"),
+    "`target` is invalid", fixed = TRUE
+  )
+  expect_error(
+    zi_load_crosswalk(zip_source = "HUD", year = 2023, qtr = 1, target = "ZIP", query = "63139"),
+    "`target` is invalid", fixed = TRUE
+  )
+})
+
+test_that("HUD valid targets are accepted without target error", {
+  valid_targets <- c("TRACT", "COUNTY", "CBSA", "CBSADIV", "CD", "COUNTYSUB")
+  for (tgt in valid_targets) {
+    # These should pass target validation — any error thrown should NOT be about target
+    err <- tryCatch(
+      zi_load_crosswalk(zip_source = "HUD", year = 2023, qtr = 1, target = tgt, query = "63139"),
+      error = function(e) conditionMessage(e)
+    )
+    # If an error occurs, it should be about the API key or something downstream, not target
+    if (is.character(err)) {
+      expect_false(grepl("`target` is invalid", err, fixed = TRUE),
+                   info = paste("target =", tgt, "errored with target validation"))
+    }
+  }
+})
+
+test_that("HUD missing query triggers appropriate error", {
+  expect_error(
+    zi_load_crosswalk(zip_source = "HUD", year = 2023, qtr = 1, target = "COUNTY", query = NULL),
+    "`query` is required", fixed = TRUE
+  )
+})
+
+# test UDS input validation ------------------------------------------------
+
+test_that("UDS year out of range triggers appropriate error", {
+  expect_error(
+    zi_load_crosswalk(zip_source = "UDS", year = 2008),
+    "`year` must be between", fixed = TRUE
+  )
+  expect_error(
+    zi_load_crosswalk(zip_source = "UDS", year = 2023),
+    "`year` must be between", fixed = TRUE
+  )
 })
 
 # test UDS crosswalk loading (requires network) ------------------------------

--- a/tests/testthat/test_zi_load_hud.R
+++ b/tests/testthat/test_zi_load_hud.R
@@ -1,0 +1,66 @@
+# test zi_load_hud() internal validation ------------------------------------------------
+
+# test API key validation ------------------------------------------------
+
+test_that("missing API key triggers appropriate error", {
+  withr::with_envvar(c("hud_key" = ""), {
+    expect_error(
+      zippeR:::zi_load_hud(year = 2023, qtr = 1, target = "COUNTY", queries = "MO", key = NULL),
+      "valid HUD API key", fixed = TRUE
+    )
+  })
+})
+
+# test year/quarter restrictions for state abbreviations ------------------------------------------------
+
+test_that("state abbreviation queries before 2021 trigger appropriate error", {
+  withr::with_envvar(c("hud_key" = "fake_key_for_testing"), {
+    expect_error(
+      zippeR:::zi_load_hud(year = 2020, qtr = 4, target = "COUNTY", queries = "MO", key = "fake_key"),
+      "only available from the first quarter", fixed = TRUE
+    )
+    expect_error(
+      zippeR:::zi_load_hud(year = 2019, qtr = 1, target = "TRACT", queries = "ALL", key = "fake_key"),
+      "only available from the first quarter", fixed = TRUE
+    )
+  })
+})
+
+# test CBSADIV availability restrictions ------------------------------------------------
+
+test_that("CBSADIV before Q4 2017 triggers appropriate error", {
+  expect_error(
+    zippeR:::zi_load_hud(year = 2016, qtr = 4, target = "CBSADIV", queries = "63139", key = "fake_key"),
+    "CBSADIV", fixed = TRUE
+  )
+  expect_error(
+    zippeR:::zi_load_hud(year = 2017, qtr = 3, target = "CBSADIV", queries = "63139", key = "fake_key"),
+    "CBSADIV", fixed = TRUE
+  )
+})
+
+# test COUNTYSUB availability restrictions ------------------------------------------------
+
+test_that("COUNTYSUB before Q2 2018 triggers appropriate error", {
+  expect_error(
+    zippeR:::zi_load_hud(year = 2017, qtr = 4, target = "COUNTYSUB", queries = "63139", key = "fake_key"),
+    "COUNTYSUB", fixed = TRUE
+  )
+  expect_error(
+    zippeR:::zi_load_hud(year = 2018, qtr = 1, target = "COUNTYSUB", queries = "63139", key = "fake_key"),
+    "COUNTYSUB", fixed = TRUE
+  )
+})
+
+# test query format validation ------------------------------------------------
+
+test_that("invalid query format triggers appropriate error", {
+  expect_error(
+    zippeR:::zi_load_hud(year = 2023, qtr = 1, target = "COUNTY", queries = "INVALID", key = "fake_key"),
+    "must be a state abbreviation", fixed = TRUE
+  )
+  expect_error(
+    zippeR:::zi_load_hud(year = 2023, qtr = 1, target = "TRACT", queries = "ABC", key = "fake_key"),
+    "must be a state abbreviation", fixed = TRUE
+  )
+})


### PR DESCRIPTION
<!-- pr-skill-managed-start -->
## Summary

Adds comprehensive offline test coverage for HUD crosswalk/loading paths — the largest blind spot identified in the test coverage audit (#43).

## Implementation

- **`test_zi_load_hud.R`** (new): Tests internal `zi_load_hud()` validation — API key, year/quarter restrictions for state abbreviations, CBSADIV/COUNTYSUB temporal availability, and query format.
- **`test_zi_load_crosswalk.R`**: Expanded with HUD-specific parameter validation (year range, quarter, all 6 targets, missing query) plus UDS out-of-range year.
- **`test_zi_crosswalk.R`**: Added HUD API-workflow validation (`by`, `return_max`, year/qtr/target/query checks) plus end-to-end tests using `zi_mo_hud` fixture with all three `by` modes and a boundary-ZIP test for `return_max = FALSE`.

## Testing

All 204 tests pass (`devtools::test()`) with 0 failures. No network or API key required — all new tests exercise validation guards deterministically.

## Closes

- Closes #58

## Notes

- No `R/` source changes — UAT not required.
- The 2 pre-existing deprecation warnings (`tidyselect`) are unrelated to this PR.
<!-- pr-skill-managed-end -->
