### PR TITLE
fix: migrate GitHub Pages deployment from JamesIves/action to official deploy-pages

### DIFF
--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -8,7 +8,10 @@ name: pkgdown
 jobs:
   pkgdown:
     runs-on: ubuntu-latest
-    # Only restrict concurrency for non-PR jobs
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     concurrency:
       group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
     env:
@@ -31,10 +34,13 @@ jobs:
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
         shell: Rscript {0}
 
-      - name: Deploy to GitHub pages 🚀
+      - name: Upload artifact
         if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@4.1.4
+        uses: actions/upload-pages-artifact@v3
         with:
-          clean: false
-          branch: gh-pages
-          folder: docs
+          path: docs
+
+      - name: Deploy to GitHub Pages
+        if: github.event_name != 'pull_request'
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

Replaces `JamesIves/github-pages-deploy-action@v4` with the official `actions/upload-pages-artifact@v3` + `actions/deploy-pages@v4` to resolve the permission denied error on gh-pages push.

## Root Cause

The `GITHUB_TOKEN` does not have write permission to force-push to the `gh-pages` branch. The third-party action relies on git push, which is blocked by the org/repo token policy.

## Changes

- Added `permissions` block with `contents: read`, `pages: write`, `id-token: write` (required for OIDC-based Pages deployment)
- Replaced `JamesIves/github-pages-deploy-action@v4` deploy step with two first-party steps:
  - `actions/upload-pages-artifact@v3` — uploads the `docs/` artifact
  - `actions/deploy-pages@v4` — deploys via GitHub Pages API (no git push needed)

## Why This Fix Works

- **No `contents: write` permission** — deploys via Pages API with OIDC instead of git push
- **First-party actions** — maintained by GitHub, not a third-party action
- **No force-push** — avoids branch protection / org policy conflicts entirely
- **More secure** — uses `id-token: write` for secure verification

## Verification

- [x] Workflow syntax is valid YAML
- [x] Only the `.github/workflows/pkgdown.yml` file is modified
- [x] No changes to application code or other workflow files
- [x] Single commit (ff8fd3d)

## Note for Maintainers

After merging, please update repo Settings → Pages → Source → select **"GitHub Actions"** (not "Deploy from a branch"). The `gh-pages` branch can be deleted once the new workflow is confirmed working.

Fixes #74