### PR TITLE
feat: extend TIGRIS year availability to 2024

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Extended TIGRIS year availability from 2023 to 2024 in `zi_get_geometry()`; `zi_list_zctas()` accepts 2024 in the valid range but aborts with an informative message until `sysdata.rda` is rebuilt (#45)
+- Updated `inst/build-data/build_vectors.R` to download and process 2024 ZCTA data, enabling future `sysdata.rda` rebuild (#45)
 - Bundled UDS Mapper crosswalk data (2009–2022, all 14 years) as `inst/extdata/uds_crosswalk.rds` (~400 KB, xz-compressed), eliminating the runtime network dependency on `chris-prener/uds-mapper` (#41)
 - `data-raw/build_uds_crosswalk.R` script documenting provenance and reproducing the bundled crosswalk file (#41)
 - Positive-path integration tests for `zi_get_geometry()`, `zi_get_demographics()`, `zi_label()`, and `zi_load_labels()` asserting on output schemas, column types, and row counts (#62)

--- a/R/zi_get_geometry.R
+++ b/R/zi_get_geometry.R
@@ -9,7 +9,7 @@
 #'
 #'
 #' @param year A four-digit numeric scalar for year. \code{zippeR} currently
-#'     supports data between 2010 and 2023
+#'     supports data between 2010 and 2024
 #' @param style A character scalar - either \code{"zcta5"} or \code{"zcta3"}.
 #'     See Details below.
 #' @param return A character scalar; if \code{"id"} (default), only the five-digit
@@ -132,9 +132,9 @@ zi_get_geometry <- function(year, style = "zcta5", return = "id", class = "sf",
     ))
   }
 
-  if (!(year %in% c(2010:2023))){
+  if (!(year %in% c(2010:2024))){
     cli::cli_abort(c(
-      "{.arg year} must be between {.val 2010} and {.val 2023}.",
+      "{.arg year} must be between {.val 2010} and {.val 2024}.",
       "i" = "You provided {.val {year}}."
     ))
   }

--- a/R/zi_list_zctas.R
+++ b/R/zi_list_zctas.R
@@ -6,7 +6,7 @@
 #'
 #'
 #' @param year A four-digit numeric scalar for year. \code{zippeR} currently
-#'     supports data between 2010 and 2021.
+#'     supports data between 2010 and 2024.
 #' @param state A scalar or vector with state abbreviations (e.x. \code{"MO"})
 #'     or FIPS codes (e.x. \code{29}).
 #' @param method A character scalar - either \code{"intersect"} or \code{"centroid"}.
@@ -46,7 +46,7 @@ zi_list_zctas <- function(year, state, method){
 
   # check inputs
   if (missing(year)){
-    cli::cli_abort("{.arg year} is required. Please provide a numeric value between {.val 2010} and {.val 2023}.")
+    cli::cli_abort("{.arg year} is required. Please provide a numeric value between {.val 2010} and {.val 2024}.")
   }
 
   if (!is.numeric(year)){
@@ -56,9 +56,9 @@ zi_list_zctas <- function(year, state, method){
     ))
   }
 
-  if (!(year %in% c(2010:2023))){
+  if (!(year %in% c(2010:2024))){
     cli::cli_abort(c(
-      "{.arg year} must be between {.val 2010} and {.val 2023}.",
+      "{.arg year} must be between {.val 2010} and {.val 2024}.",
       "i" = "You provided {.val {year}}."
     ))
   }

--- a/R/zi_list_zctas.R
+++ b/R/zi_list_zctas.R
@@ -63,6 +63,13 @@ zi_list_zctas <- function(year, state, method){
     ))
   }
 
+  if (year == 2024){
+    cli::cli_abort(c(
+      "{.arg year} {.val 2024} is not yet available for {.fn zi_list_zctas}.",
+      "i" = "Use {.val 2023} or earlier. Support for {.val 2024} will be added in a future release."
+    ))
+  }
+
   if (missing(state)){
     cli::cli_abort("{.arg state} is required.")
   }

--- a/inst/build-data/README.md
+++ b/inst/build-data/README.md
@@ -15,7 +15,7 @@ must be run first.
 **What it does:**
 
 1. Downloads US state boundaries from the Census Bureau (via `tigris::states()`).
-2. Downloads ZCTA shapefiles for every available year (2010, 2012–2023) from the
+2. Downloads ZCTA shapefiles for every available year (2010, 2012–2024) from the
    Census Bureau (via `tigris::zctas()`).
 3. Intersects ZCTAs with state boundaries using two methods (geometric
    intersection and centroid containment) to produce per-state ZCTA vectors for

--- a/inst/build-data/build_vectors.R
+++ b/inst/build-data/build_vectors.R
@@ -165,6 +165,13 @@ st_geometry(states_lookup) <- NULL
 # Process ZCTA Data, Intersects ####
 if (style == FALSE){
 
+  zctas <- zctas(year = 2024, class = "sf")
+  zcta2024 <- create_year(year = 2024, zcta = zctas, intersect_by = states_abbrev)
+  save(zcta2024, file = "inst/data-raw/zcta2024.rda")
+
+  zcta2024 <- create_year(year = 2024, zcta = zctas, intersect_by = states_abbrev, method = "centroid")
+  save(zcta2024, file = "inst/data-raw/zcta2024_centroid.rda")
+
   zctas <- zctas(year = 2023, class = "sf")
   zcta2023 <- create_year(year = 2023, zcta = zctas, intersect_by = states_abbrev)
   save(zcta2023, file = "inst/data-raw/zcta2023.rda")
@@ -260,7 +267,7 @@ if (style == FALSE){
 
 # Compare ZCTA Data, Intersects ####
 ## Load ZCTA Data ####
-c(2010,2012:2023) %>%
+c(2010,2012:2024) %>%
   unlist() %>%
   map(~load(file = paste0("inst/data-raw/zcta", .x, ".rda"), envir = .GlobalEnv))
 
@@ -301,28 +308,28 @@ changes2021 <- id_changes(year1 = zcta2020, year2 = zcta2021,
 changes2022 <- id_changes(year1 = zcta2021, year2 = zcta2022,
                           name = states_abbrev, year = 2022)
 
-changes2023 <- id_changes(year1 = zcta2022, year2 = zcta2023,
-                          name = states_abbrev, year = 2023)
+changes2024 <- id_changes(year1 = zcta2023, year2 = zcta2024,
+                          name = states_abbrev, year = 2024)
 
 
 ### combine comparisons
 changes <- c(zcta2010, changes2012, changes2013, changes2014, changes2015,
              changes2016, changes2017, changes2018, changes2019, changes2020,
-             changes2021, changes2022, changes2023)
+             changes2021, changes2022, changes2023, changes2024)
 changes <- changes[order(names(changes))]
 
 ### clean-up
 rm(zcta2010, zcta2012, zcta2013, zcta2014, zcta2015, zcta2016, zcta2017,
-   zcta2018, zcta2019, zcta2020, zcta2021, zcta2022, zcta2023)
+   zcta2018, zcta2019, zcta2020, zcta2021, zcta2022, zcta2023, zcta2024)
 rm(changes2012, changes2013, changes2014, changes2015, changes2016,
    changes2017, changes2018, changes2019, changes2020, changes2021,
-   changes2022, changes2023)
+   changes2022, changes2023, changes2024)
 
 # Create Reference Table Data, Intersects ####
 ## reference data
 reference <- data.frame(
-  state = sort(rep(states_abbrev$STUSPS, length(2010:2023))),
-  year = rep(2010:2023, length(states_abbrev$STUSPS))
+  state = sort(rep(states_abbrev$STUSPS, length(2010:2024))),
+  year = rep(2010:2024, length(states_abbrev$STUSPS))
 )
 
 reference <- left_join(reference, states_lookup, by = c("state" = "abb")) %>%
@@ -346,7 +353,7 @@ rm(states)
 
 # Compare ZCTA Data, Centroids ####
 ## Load ZCTA Data ####
-c(2010,2012:2023) %>%
+c(2010,2012:2024) %>%
   unlist() %>%
   map(~load(file = paste0("inst/data-raw/zcta", .x, "_centroid.rda"), envir = .GlobalEnv))
 
@@ -390,26 +397,29 @@ changes2022 <- id_changes(year1 = zcta2021, year2 = zcta2022,
 changes2023 <- id_changes(year1 = zcta2022, year2 = zcta2023,
                           name = states_abbrev, year = 2023)
 
+changes2024 <- id_changes(year1 = zcta2023, year2 = zcta2024,
+                          name = states_abbrev, year = 2024)
+
 ### combine comparisons
 changes <- c(zcta2010, changes2012, changes2013, changes2014, changes2015,
              changes2016, changes2017, changes2018, changes2019, changes2020,
-             changes2021)
+             changes2021, changes2022, changes2023, changes2024)
 changes <- c(changes, AS12 = "96799")
 changes <- changes[order(names(changes))]
 
 ### clean-up
 rm(zcta2010, zcta2012, zcta2013, zcta2014, zcta2015, zcta2016, zcta2017,
-   zcta2018, zcta2019, zcta2020, zcta2021, zcta2022, zcta2023)
+   zcta2018, zcta2019, zcta2020, zcta2021, zcta2022, zcta2023, zcta2024)
 rm(changes2012, changes2013, changes2014, changes2015, changes2016,
    changes2017, changes2018, changes2019, changes2020, changes2021,
-   changes2022, changes2023)
+   changes2022, changes2023, changes2024)
 rm(compare_years, id_changes, pull_changes, update_names)
 
 # Create Reference Table Data, Centroids ####
 ## reference data
 reference <- data.frame(
-  state = sort(rep(states_abbrev$STUSPS, length(2010:2023))),
-  year = rep(2010:2023, length(states_abbrev$STUSPS))
+  state = sort(rep(states_abbrev$STUSPS, length(2010:2024))),
+  year = rep(2010:2024, length(states_abbrev$STUSPS))
 )
 
 reference <- left_join(reference, states_lookup, by = c("state" = "abb")) %>%
@@ -452,7 +462,8 @@ zcta3_url <- list(
   zcta3_2020 = "https://raw.githubusercontent.com/chris-prener/zcta3/main/data/zcta3_2020.geojson",
   zcta3_2021 = "https://raw.githubusercontent.com/chris-prener/zcta3/main/data/zcta3_2021.geojson",
   zcta3_2022 = "https://raw.githubusercontent.com/chris-prener/zcta3/main/data/zcta3_2022.geojson",
-  zcta3_2023 = "https://raw.githubusercontent.com/chris-prener/zcta3/main/data/zcta3_2023.geojson"
+  zcta3_2023 = "https://raw.githubusercontent.com/chris-prener/zcta3/main/data/zcta3_2023.geojson",
+  zcta3_2024 = "https://raw.githubusercontent.com/chris-prener/zcta3/main/data/zcta3_2024.geojson"
 )
 
 # Create American Samoa Bounding Box ####

--- a/inst/build-data/build_vectors.R
+++ b/inst/build-data/build_vectors.R
@@ -308,6 +308,9 @@ changes2021 <- id_changes(year1 = zcta2020, year2 = zcta2021,
 changes2022 <- id_changes(year1 = zcta2021, year2 = zcta2022,
                           name = states_abbrev, year = 2022)
 
+changes2023 <- id_changes(year1 = zcta2022, year2 = zcta2023,
+                          name = states_abbrev, year = 2023)
+
 changes2024 <- id_changes(year1 = zcta2023, year2 = zcta2024,
                           name = states_abbrev, year = 2024)
 

--- a/tests/testthat/test_zi_get_geometry.R
+++ b/tests/testthat/test_zi_get_geometry.R
@@ -2,6 +2,7 @@
 
 chr_year <- "2010"
 incorrect_year <- 2009
+out_of_range_year <- 2025
 correct_year <- 2011
 
 # test errors ------------------------------------------------
@@ -10,6 +11,8 @@ test_that("incorrectly specified parameters trigger appropriate errors", {
   expect_error(zi_get_geometry(year = chr_year, method = "centroid"),
                "`year` must be numeric", fixed = TRUE)
   expect_error(zi_get_geometry(year = incorrect_year, method = "centroid"),
+               "`year` must be between", fixed = TRUE)
+  expect_error(zi_get_geometry(year = out_of_range_year, method = "centroid"),
                "`year` must be between", fixed = TRUE)
   expect_error(zi_get_geometry(year = correct_year, style = "zcta", method = "centroid"),
                "`style` must be", fixed = TRUE)

--- a/tests/testthat/test_zi_list_zctas.R
+++ b/tests/testthat/test_zi_list_zctas.R
@@ -2,6 +2,7 @@
 
 incorrect_year_str <- "2010"
 incorrect_year_num <- 2009
+out_of_range_year <- 2025
 incorrect_method <- "ham"
 
 correct_year <- 2010
@@ -19,6 +20,8 @@ test_that("incorrectly specified parameters trigger appropriate errors", {
   expect_error(zi_list_zctas(year = incorrect_year_str, method = correct_method, state = states),
                "`year` must be numeric", fixed = TRUE)
   expect_error(zi_list_zctas(year = incorrect_year_num, method = correct_method, state = states),
+               "`year` must be between", fixed = TRUE)
+  expect_error(zi_list_zctas(year = out_of_range_year, method = correct_method, state = states),
                "`year` must be between", fixed = TRUE)
   expect_error(zi_list_zctas(method = incorrect_method, year = correct_year, state = states),
                "`method` must be", fixed = TRUE)

--- a/tests/testthat/test_zi_list_zctas.R
+++ b/tests/testthat/test_zi_list_zctas.R
@@ -3,6 +3,7 @@
 incorrect_year_str <- "2010"
 incorrect_year_num <- 2009
 out_of_range_year <- 2025
+unavailable_year <- 2024
 incorrect_method <- "ham"
 
 correct_year <- 2010
@@ -23,6 +24,8 @@ test_that("incorrectly specified parameters trigger appropriate errors", {
                "`year` must be between", fixed = TRUE)
   expect_error(zi_list_zctas(year = out_of_range_year, method = correct_method, state = states),
                "`year` must be between", fixed = TRUE)
+  expect_error(zi_list_zctas(year = unavailable_year, method = correct_method, state = states),
+               "is not yet available", fixed = TRUE)
   expect_error(zi_list_zctas(method = incorrect_method, year = correct_year, state = states),
                "`method` must be", fixed = TRUE)
   expect_warning(


### PR DESCRIPTION
## Summary

Extends TIGRIS year availability from 2023 to 2024 in `zi_get_geometry()` and `zi_list_zctas()`, matching Census Bureau TIGER/Line 2024 vintage availability. Includes a temporary abort guard in `zi_list_zctas()` for `year = 2024` until `R/sysdata.rda` is rebuilt.

> ⚠️ **UAT required** — `R/zi_get_geometry.R` and `R/zi_list_zctas.R` were modified. Please verify behavior before merging (see Testing section).

## Changes

- `R/zi_get_geometry.R`: year range `2010:2023` → `2010:2024`; `@param year` doc updated
- `R/zi_list_zctas.R`: year range `2010:2023` → `2010:2024`; abort guard for `year == 2024` with message "not yet available — use 2023 or earlier"; `@param year` doc updated
- `inst/build-data/build_vectors.R`: full 2024 support for future `sysdata.rda` rebuild (download block, `id_changes` comparisons, combine steps, reference table year ranges, `zcta3_2024` URL)
- `inst/build-data/README.md`: year range updated to 2024
- `CHANGELOG.md`: [Unreleased] entry added

## Why partial

`zi_list_zctas()` relies on prebuilt reference data in `R/sysdata.rda` (not live tigris calls). The `sysdata.rda` rebuild via `inst/build-data/build_vectors.R` is time-intensive and must be run separately. The abort guard prevents silent failures in the meantime. A follow-up task will complete the rebuild and remove the guard.

## Testing

All 269 unit tests pass (26 skipped — live API integration tests):

```
Rscript -e 'testthat::test_local(".")'
```

New tests added:
- `test_zi_get_geometry.R`: year 2025 fails range check
- `test_zi_list_zctas.R`: year 2025 fails range check; year 2024 fires the "not yet available" abort

**Manual UAT to verify before merge:**
1. `zi_get_geometry(year = 2024, ...)` (no state filter) works
2. `zi_list_zctas(year = 2024, ...)` aborts with "not yet available" message
3. `zi_list_zctas(year = 2025, ...)` fails with "must be between" range error

## Related

Closes #45
