### PR TITLE
feat: reduce dependencies — replace httr, readr, tidyr with base/httr2 (Epic E Phase 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ inst/doc
 docs/WORKFLOW.md
 docs/README.md
 .positai
+.github/audit-reports/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Drop `purrr` from `Imports`; replace `purrr::map_dfr()` in `zi_load_hud()` with `do.call(rbind, lapply())` (#80)
 - Drop `spatstat.univar` from `Imports`; replace `weighted.median()` calls with an internal `weighted_median()` base-R helper in `R/zi_utils.R` (#81)
 - Drop `stringr` from `Imports`; replace `str_pad()`, `str_trim()`, and `word()` calls with base-R equivalents (`formatC`, `trimws`, `sub`) across `R/zi_aggregate.R`, `R/zi_get_demographics.R`, `R/zi_utils.R`, and `R/zi_validate.R` (#82)
+- Drop `httr` from `Imports`; replace `httr::GET()` / `httr::content()` / `httr::http_error()` with `httr2::request() |> httr2::req_perform()` / `httr2::resp_body_string()` / `httr2_http_error` condition handler in `R/zi_load_crosswalk.R`; add `httr2 (>= 1.0.0)` to `Imports` (#83)
+- Drop `readr` from `Imports`; replace `readr::read_csv()` with `utils::read.csv()` (using `colClasses` for character-type enforcement) in `R/zi_load_labels.R` (#84)
+- Drop `tidyr` from `Imports`; replace `tidyr::pivot_wider()` with `stats::reshape()` for both the decennial (single-value) and ACS (estimate+moe) wide-output paths in `R/zi_aggregate.R` (#85)
 
 ### Added
 - Data provenance README in `inst/build-data/` documenting build scripts, execution order, prerequisites, and outputs (#20)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,13 +30,11 @@ Config/testthat/edition: 3
 Imports:
     cli (>= 3.0.0),
     dplyr (>= 1.0.0),
-    httr (>= 1.4.0),
+    httr2 (>= 1.0.0),
     jsonlite (>= 1.7.0),
-    readr (>= 2.0.0),
     sf (>= 1.0-0),
     tibble (>= 3.0.0),
     tidycensus (>= 1.0),
-    tidyr (>= 1.0.0),
     tigris (>= 1.0)
 Suggests:
     knitr,

--- a/R/zi_aggregate.R
+++ b/R/zi_aggregate.R
@@ -328,16 +328,24 @@ zi_aggregate <- function(.data, year, extensive = NULL, intensive = NULL,
 
       if (survey %in% c("sf1", "sf3")){
         ## pivot decennial (single value column)
-        out <- tidyr::pivot_wider(out, id_cols = "ZCTA3", names_from = "variable",
-                                  values_from = "value")
+        out <- stats::reshape(as.data.frame(out), idvar = "ZCTA3", timevar = "variable",
+                              direction = "wide", v.names = "value")
+        names(out) <- sub("^value\\.", "", names(out))
+        rownames(out) <- NULL
+        out <- tibble::as_tibble(out)
       } else {
         ## prep names
         out <- dplyr::rename(out, "E" = "estimate", "M" = "moe")
 
-        ## pivot
-        out <- tidyr::pivot_wider(out, id_cols = "ZCTA3", names_from = "variable",
-                                  names_glue = "{variable}{.value}",
-                                  values_from = c("E", "M"))
+        ## pivot ACS (estimate + moe columns)
+        out <- stats::reshape(as.data.frame(out), idvar = "ZCTA3", timevar = "variable",
+                              direction = "wide", v.names = c("E", "M"))
+        nms <- names(out)
+        nms <- sub("^E\\.(.+)$", "\\1E", nms)
+        nms <- sub("^M\\.(.+)$", "\\1M", nms)
+        names(out) <- nms
+        rownames(out) <- NULL
+        out <- tibble::as_tibble(out)
       }
 
       ## re-order names alphabetically

--- a/R/zi_load_crosswalk.R
+++ b/R/zi_load_crosswalk.R
@@ -236,17 +236,19 @@ zi_load_hud <- function(year, qtr, target, queries, key = NULL){
     }
 
     # get data and format
-    request <- httr::GET(paste0(url, type, query, "&year=", year, "&quarter=", qtr), httr::add_headers(Authorization = paste("Bearer", key, sep = " ")))
+    request <- tryCatch(
+      httr2::request(paste0(url, type, query, "&year=", year, "&quarter=", qtr)) |>
+        httr2::req_headers(Authorization = paste("Bearer", key)) |>
+        httr2::req_perform(),
+      httr2_http_error = function(e) {
+        cli::cli_abort(c(
+          "x" = "HUD API request failed with status {.val {httr2::resp_status(e$resp)}}.",
+          "i" = "Check your API key and query parameters (year={year}, qtr={qtr}, query={query})."
+        ))
+      }
+    )
 
-    # validate HTTP status
-    if (httr::http_error(request)){
-      cli::cli_abort(c(
-        "x" = "HUD API request failed with status {.val {httr::status_code(request)}}.",
-        "i" = "Check your API key and query parameters (year={year}, qtr={qtr}, query={query})."
-      ))
-    }
-
-    content <- httr::content(request, "text", encoding = "UTF-8")
+    content <- httr2::resp_body_string(request)
     json <- jsonlite::fromJSON(content)
     list <- lapply(json, "[[", 5)
 

--- a/R/zi_load_labels.R
+++ b/R/zi_load_labels.R
@@ -148,12 +148,10 @@ zi_load_labels_usps <- function(type, include_scf, vintage){
 
     ## read from GitHub
     out <- tryCatch(
-      readr::read_csv(
+      utils::read.csv(
         paste0("https://raw.githubusercontent.com/chris-prener/usps-zip-ref/main/data/zip3_", vintage, ".csv"),
-        col_types = readr::cols(
-          zip3 = readr::col_character(),
-          scf_id = readr::col_character()
-        )
+        colClasses = c(zip3 = "character", scf_id = "character"),
+        stringsAsFactors = FALSE
       ),
       error = function(e) {
         cli::cli_abort(c(
@@ -162,6 +160,7 @@ zi_load_labels_usps <- function(type, include_scf, vintage){
         ))
       }
     )
+    out <- tibble::as_tibble(out)
 
     ## rename cols
     out <- dplyr::rename(out, label_area = destination_area, label_state = destination_state)


### PR DESCRIPTION
<!-- pr-skill-managed-start -->
## Summary

Implements Phase 2 of Epic E dependency reduction. Removes three package dependencies (`httr`, `readr`, `tidyr`) by replacing them with lighter-weight alternatives.

Closes #83, #84, #85

## Changes

- **#83** (`R/zi_load_crosswalk.R`): Replaced `httr` with `httr2` — migrated GET/http_error/status_code/content to `httr2::request() |> req_headers() |> req_perform()` with `tryCatch(httr2_http_error = ...)` error handling.
- **#84** (`R/zi_load_labels.R`): Replaced `readr::read_csv()` with `utils::read.csv()` using `colClasses` for character column preservation; result wrapped with `tibble::as_tibble()`.
- **#85** (`R/zi_aggregate.R`): Replaced both `tidyr::pivot_wider()` calls with `stats::reshape()` for decennial and ACS paths.
- **`DESCRIPTION`**: Removed `httr`, `readr`, `tidyr` from Imports; added `httr2 (>= 1.0.0)`.
- **`CHANGELOG.md`**: Added 3 bullets to `[Unreleased] ### Removed` referencing #83, #84, #85.
- **`.gitignore`**: Added `.github/audit-reports/` for QC gate reports.

## Testing

- 269 unit tests pass, 0 failures, 0 warnings, 26 integration tests skipped (expected).
- ACS and decennial wide-output reshape paths both exercised without API calls.

## UAT Required — R/ Changes

**This PR modifies files in `R/`:**
- `R/zi_load_crosswalk.R`
- `R/zi_load_labels.R`
- `R/zi_aggregate.R`

Per the repo human-in-the-loop policy, **UAT is required before merging.** Please verify:
1. `zi_load_hud()` fetches crosswalk data correctly via httr2.
2. `zi_load_labels()` (USPS path) returns expected schema with character ZIP columns.
3. `zi_aggregate()` with `output = "wide"` produces correctly named columns for both decennial and ACS data.

**Do NOT merge until UAT sign-off is confirmed.**

## PR Lifecycle Gates

| Gate | Status |
|---|---|
| Plan handoff (#83, #84, #85) | Passed |
| Code review (rubber-duck) | CLEAN |
| Retrospective + plan transition | Posted & Shipped |
| Changelog | Added |
| Pre-PR QC | CLEAN (0 findings) |
<!-- pr-skill-managed-end -->
