### PR TITLE
fix: resolve pkgdown build and Pages deployment failures

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -93,7 +93,7 @@ jobs:
         with:
           cache: TRUE
           install-pandoc: TRUE
-          extra-packages: any::rcmdcheck
+          extra-packages: any::rcmdcheck, any::spelling
           needs: check
 
       - name: Session Info
@@ -111,3 +111,15 @@ jobs:
           args: 'c("--no-manual", "--as-cran")'
         env:
           _R_CHECK_DONTTEST_EXAMPLES_: false
+
+      - name: Spell check
+        if: matrix.config.os == 'ubuntu-latest' && matrix.config.r == 'release'
+        run: |
+          if (requireNamespace("spelling", quietly = TRUE)) {
+            results <- spelling::spell_check_package()
+            if (nrow(results) > 0) {
+              print(results)
+              stop("Spelling errors found. Update inst/WORDLIST if terms are correct.")
+            }
+          }
+        shell: Rscript {0}

--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -5,12 +5,21 @@ on:
 
 name: pkgdown
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 jobs:
   pkgdown:
     runs-on: ubuntu-latest
-    # Only restrict concurrency for non-PR jobs
-    concurrency:
-      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -29,13 +38,14 @@ jobs:
           needs: website
 
       - name: Build site
-        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE, dest_dir = "_site")
         shell: Rscript {0}
 
-      - name: Deploy to GitHub pages 🚀
-        if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@4.1.4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          clean: false
-          branch: gh-pages
-          folder: docs
+          path: ./_site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ docs/WORKFLOW.md
 docs/README.md
 .positai
 .github/audit-reports/
+
+# pkgdown build output
+_site/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `zi_convert()` using `substitute(input_var)` instead of `substitute(output_var)` when `output_var` is specified, which caused the input column to be overwritten instead of creating a new output column (#33)
 - Replace live Census API calls in `test_zi_aggregate.R` with local fixtures so `R CMD check` passes on CRAN without a Census API key (#6)
 - Normalize non-standard column names in 2015 UDS crosswalk (`zcta_use` → `zcta`, etc.) so `zi_load_crosswalk(zip_source = "UDS", year = 2015)` no longer errors (#5)
+- Fix pkgdown CI build failure caused by non-empty `docs/` directory conflict; pkgdown now builds to `_site/` (#70)
+- Replace `JamesIves/github-pages-deploy-action` with first-party OIDC-based `actions/upload-pages-artifact` + `actions/deploy-pages` to resolve GitHub Pages deployment permission error (#74)
 
 ### Changed
 - Replace `\donttest{}` / `\dontrun{}` wrappers in roxygen2 examples with `@examplesIf interactive()` (network-dependent examples) and `@examplesIf nzchar(Sys.getenv("hud_key"))` (HUD API key examples) across all 9 affected source files (#77)

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,5 +1,7 @@
 url: https://pfizer-opensource.github.io/zippeR/
 
+destination: _site
+
 template:
   bootstrap: 5
 


### PR DESCRIPTION
<!-- pr-skill-managed-start -->
## Summary

Resolves two related pkgdown CI failures:

1. **#70 — Build failure**: `pkgdown::build_site_github_pages()` refused to write to `docs/` because the directory contains hand-authored repo documentation (ARCHITECTURE.md, ROADMAP.md, etc.), not pkgdown output. Fixed by redirecting pkgdown output to `_site/` via `dest_dir = "_site"` in the workflow and `destination: _site` in `_pkgdown.yml`. Added `_site/` to `.gitignore`.

2. **#74 — Deployment permission error**: The third-party `JamesIves/github-pages-deploy-action@4.1.4` was denied push access to `gh-pages` due to org token policy. Fixed by replacing it with GitHub's first-party OIDC-based `actions/upload-pages-artifact@v3` + `actions/deploy-pages@v4`, which deploys via the Pages API with no `contents: write` needed.

Also adds `any::spelling` and a spell-check step to `R-CMD-check.yaml` (pattern from deprivateR).

## Implementation

- `.github/workflows/pkgdown.yml`: full rewrite — OIDC permissions (`pages: write`, `id-token: write`), `dest_dir = "_site"`, replaces JamesIves action with first-party deploy pair, adds `environment: github-pages` block.
- `_pkgdown.yml`: adds `destination: _site`.
- `.gitignore`: adds `_site/`.
- `.github/workflows/R-CMD-check.yaml`: adds `any::spelling` to extra-packages and a spell-check step (ubuntu/release only).

> ⚠️ **Manual step required before merging**: Go to **Settings → Pages → Source** and select **"GitHub Actions"** (not "Deploy from a branch"). This is required for `actions/deploy-pages` to work.

## Testing

CI-only changes. R CMD check and pkgdown workflows will validate on push. No R source changes — no UAT required.

## Closes

Closes #70
Closes #74

## Notes

_no-prep-gate: CI/workflow-only changes with no R source modifications; QC gate not applicable._
_created: 2026-06-02T04:52:00Z_
<!-- pr-skill-managed-end -->
