### PR TITLE
chore: update CRAN submission artifacts for 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Updated `NEWS.md`, `README.md`/`README.Rmd`, and `cran-comments.md` with full 0.2.0 release notes, a "What's New" section, and expanded CRAN reviewer summary (#73)
+
 ### Added
 - Extended TIGRIS year availability from 2023 to 2024 in `zi_get_geometry()`; `zi_list_zctas()` accepts 2024 in the valid range but aborts with an informative message until `sysdata.rda` is rebuilt (#45)
 - Updated `inst/build-data/build_vectors.R` to download and process 2024 ZCTA data, enabling future `sysdata.rda` rebuild (#45)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,24 @@
 # zippeR 0.2.0
 
-* Bump version for next CRAN release
+## New features and improvements
+
+* UDS Mapper crosswalk data (2009–2022) is now bundled with the package, eliminating the runtime network dependency on an external GitHub repository
+* Partial support for 2024 TIGRIS year: `zi_list_zctas()` accepts 2024 in its valid range, and `zi_get_geometry()` accepts the argument but aborts with an informative message until internal data is rebuilt in a future release
+* Deprecated parameter aliases `input_zip` and `dict` in `zi_crosswalk()` with backwards-compatible support until early 2027
+* `@examplesIf` guards replace `\donttest{}`/`\dontrun{}` wrappers in all network-dependent and API-key-dependent examples
+* Minimum R version set to 4.1
+
+## Bug fixes
+
+* Resolved several input validation gaps across `zi_aggregate()`, `zi_crosswalk()`, `zi_convert()`, `zi_get_geometry()`, `zi_get_demographics()`, `zi_load_crosswalk()`, `zi_load_labels()`, `zi_load_labels_list()`, `zi_prep_hud()`, `zi_repair()`, and `zi_validate()`
+* Fixed a number of incorrect column references, variable scoping errors, and unsafe dispatch patterns identified during a code quality audit
+* Replaced live Census API calls in tests with local fixtures so `R CMD check` passes on CRAN without a Census API key
+* Normalized non-standard column names in the 2015 UDS crosswalk
+
+## Dependency changes
+
+* Dropped `purrr`, `spatstat.univar`, `stringr`, `httr`, `readr`, and `tidyr` from Imports
+* Added `httr2 (>= 1.0.0)` to Imports
 
 # zippeR 0.1.2
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -38,12 +38,22 @@ The development version of `zippeR` can be accessed from GitHub with `remotes`:
 remotes::install_github("pfizer-opensource/zippeR")
 ```
 
+## What's New in v0.2.0
+
+* **Bundled UDS crosswalk data** — The UDS Mapper ZIP-to-ZCTA crosswalk files (2009–2022) are now included directly in the package, so `zi_load_crosswalk()` no longer requires a network connection for UDS lookups.
+* **Lighter dependency footprint** — Six packages (`purrr`, `spatstat.univar`, `stringr`, `httr`, `readr`, and `tidyr`) have been dropped from Imports, replaced with base-R equivalents or `httr2`.
+* **Bug fix and input validation sweep** — A code quality audit identified and resolved a broad set of issues including incorrect column references, unsafe dispatch patterns, and missing input guards across nearly all major functions.
+* **Partial 2024 TIGRIS year support** — `zi_list_zctas()` and `zi_get_geometry()` now accept 2024 as a valid year; full geometry data for 2024 will be available in a future release.
+
+See `NEWS.md` for the full list of changes.
+
 ## Usage
 `zippeR` contains functions that support the following tasks:
   * Labeling five-digit and three-digit ZIP Codes
   * Converting ZIP Codes to ZCTAs, counties, and other Census geographies
   * Downloading ZCTA geometries for both five-digit and three-digit areas
   * Aggregating demographic data from five-digit ZCTAs to three-digit ZCTAs
+  * Accessing bundled, offline UDS Mapper ZIP-to-ZCTA crosswalk data (2009–2022)
 
 While a quick overview of the the core functionality is below, see the vignettes and our package website for more information on how to use these functions.
 
@@ -68,7 +78,7 @@ The `zi_load_crosswalk()` function provides access to the former UDS Mapper proj
 # … with 41,086 more rows
 ```
 
-Likewise, users can use the `zip_load_crosswalk()` function combined with a HUD API key to access the HUD USPS ZIP Code Crosswalk. This function returns a data frame with ZIP Codes and their corresponding Census geographies:
+Likewise, users can use the `zi_load_crosswalk()` function combined with a HUD API key to access the HUD USPS ZIP Code Crosswalk. This function returns a data frame with ZIP Codes and their corresponding Census geographies:
 
 ```r
 zi_load_crosswalk(zip_source = "HUD", year = 2023, qtr = 1, target = "COUNTY",

--- a/README.md
+++ b/README.md
@@ -39,13 +39,33 @@ The development version of `zippeR` can be accessed from GitHub with
 remotes::install_github("pfizer-opensource/zippeR")
 ```
 
+## What’s New in v0.2.0
+
+- **Bundled UDS crosswalk data** — The UDS Mapper ZIP-to-ZCTA crosswalk
+  files (2009–2022) are now included directly in the package, so
+  `zi_load_crosswalk()` no longer requires a network connection for UDS
+  lookups.
+- **Lighter dependency footprint** — Six packages (`purrr`,
+  `spatstat.univar`, `stringr`, `httr`, `readr`, and `tidyr`) have been
+  dropped from Imports, replaced with base-R equivalents or `httr2`.
+- **Bug fix and input validation sweep** — A code quality audit
+  identified and resolved a broad set of issues including incorrect
+  column references, unsafe dispatch patterns, and missing input guards
+  across nearly all major functions.
+- **Partial 2024 TIGRIS year support** — `zi_list_zctas()` and
+  `zi_get_geometry()` now accept 2024 as a valid year; full geometry
+  data for 2024 will be available in a future release.
+
+See `NEWS.md` for the full list of changes.
+
 ## Usage
 
 `zippeR` contains functions that support the following tasks: \*
 Labeling five-digit and three-digit ZIP Codes \* Converting ZIP Codes to
 ZCTAs, counties, and other Census geographies \* Downloading ZCTA
 geometries for both five-digit and three-digit areas \* Aggregating
-demographic data from five-digit ZCTAs to three-digit ZCTAs
+demographic data from five-digit ZCTAs to three-digit ZCTAs \* Accessing
+bundled, offline UDS Mapper ZIP-to-ZCTA crosswalk data (2009–2022)
 
 While a quick overview of the the core functionality is below, see the
 vignettes and our package website for more information on how to use
@@ -75,10 +95,10 @@ data frame with ZIP Codes and their corresponding ZCTAs.
 # … with 41,086 more rows
 ```
 
-Likewise, users can use the `zip_load_crosswalk()` function combined
-with a HUD API key to access the HUD USPS ZIP Code Crosswalk. This
-function returns a data frame with ZIP Codes and their corresponding
-Census geographies:
+Likewise, users can use the `zi_load_crosswalk()` function combined with
+a HUD API key to access the HUD USPS ZIP Code Crosswalk. This function
+returns a data frame with ZIP Codes and their corresponding Census
+geographies:
 
 ``` r
 zi_load_crosswalk(zip_source = "HUD", year = 2023, qtr = 1, target = "COUNTY",

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,5 +1,11 @@
 ## Release summary
-This is a minor release of `zippeR` (0.2.0) for CRAN.
+This is a minor release of `zippeR` (0.2.0) for CRAN. Key changes include:
+
+* Bundled UDS Mapper ZIP-to-ZCTA crosswalk data (2009–2022) directly in the package, removing the runtime network dependency on an external GitHub repository
+* Dropped six packages from Imports (`purrr`, `spatstat.univar`, `stringr`, `httr`, `readr`, `tidyr`), replacing them with base-R equivalents or `httr2`
+* Resolved a broad set of input validation gaps, incorrect column references, and unsafe dispatch patterns identified during a code quality audit
+* Replaced live Census API calls in the test suite with local fixtures so checks pass on CRAN without a Census API key
+* Set minimum R version to 4.1
 
 ## Test environments
 * local macOS install: R 4.4.3


### PR DESCRIPTION
<!-- pr-skill-managed-start -->
## Summary

Updates the three CRAN submission artifacts for the 0.2.0 release. All blocking dependencies (#75, #76) are resolved; this is the final pre-submission documentation pass.

## Implementation

- **`NEWS.md`**: Replaced placeholder entry with a full structured changelog in CRAN NEWS format — three sections: New features and improvements, Bug fixes, Dependency changes.
- **`README.Rmd` → `README.md`**: Added a "What's New in v0.2.0" section after Installation; updated the Usage feature list to mention bundled offline UDS crosswalk access; fixed a `zip_load_crosswalk` → `zi_load_crosswalk` typo in the HUD example prose. Re-rendered with `rmarkdown::render()` (not bare `knitr::knit()`) to prevent YAML frontmatter leaking into the output.
- **`cran-comments.md`**: Expanded one-line release summary into five descriptive bullets for CRAN reviewers.
- **`CHANGELOG.md`**: Added `[Unreleased]` entry for this PR.

## Testing

No R code changes — prose and submission artifacts only. `R CMD check` results (0E/0W/0N) already verified in #76.

## Closes

Closes #73

## Notes

_created: 2026-06-02T05:18:00Z_
<!-- pr-skill-managed-end -->
