### PR TITLE
fix: extend zi_get_demographics()/zi_aggregate() acs1/acs5 year support to 2024

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Test coverage for HUD crosswalk/loading paths: input validation for `zi_load_crosswalk()`, `zi_crosswalk()`, and internal `zi_load_hud()` helper; end-to-end custom dictionary tests (#58)
 
 ### Fixed
+- Extended `zi_get_demographics()` and `zi_aggregate()` `acs1`/`acs5` year-range validation from 2010-2022 to 2010-2024, bringing them in line with `zi_get_geometry()`'s currently-working 2023 support; live-verified against the Census API for both 2023 and 2024 ACS5 vintages (#103)
 - Fix N/A ZCTA rows in 2009 UDS data being incorrectly zero-padded to `"00N/A"` instead of being filtered out; normalization now removes N/A ZCTAs before zero-padding (#41)
 - Replace `eval(parse(text = ...))` dispatch in `zi_utils.R` with safer `getExportedValue()` (#60)
 - Replace `tigris::states()` network download in `zi_prep_hud()` with static `states_lookup` for faster, offline-capable execution (#60)

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 
 ## Bug fixes
 
+* `zi_get_demographics()` and `zi_aggregate()` now accept `year` values through 2024 for `survey` values `"acs1"` and `"acs5"` (previously capped at 2022), bringing them in line with `zi_get_geometry()`'s currently-working 2023 support. Note that `zi_get_geometry()`/`zi_list_zctas()` still only support ZCTA geometry through 2023; full 2024 geometry support is tracked in a follow-up issue pending an internal data rebuild
 * Resolved several input validation gaps across `zi_aggregate()`, `zi_crosswalk()`, `zi_convert()`, `zi_get_geometry()`, `zi_get_demographics()`, `zi_load_crosswalk()`, `zi_load_labels()`, `zi_load_labels_list()`, `zi_prep_hud()`, `zi_repair()`, and `zi_validate()`
 * Fixed a number of incorrect column references, variable scoping errors, and unsafe dispatch patterns identified during a code quality audit
 * Replaced live Census API calls in tests with local fixtures so `R CMD check` passes on CRAN without a Census API key

--- a/R/zi_aggregate.R
+++ b/R/zi_aggregate.R
@@ -11,9 +11,9 @@
 #'     plan to use for aggregating data. See Details below for formatting
 #'     requirements.
 #' @param year A four-digit numeric scalar for year. \code{zippeR} currently
-#'     supports data for from 2010 to 2022. Different \code{survey} products
-#'     are available for different years. See the \code{survey} parameter
-#'     for more details.
+#'     supports data for \code{"acs1"} and \code{"acs5"} from 2010 to 2024.
+#'     Different \code{survey} products are available for different years.
+#'     See the \code{survey} parameter for more details.
 #' @param extensive A character scalar or vector listing all extensive (i.e.
 #'     count data) variables you wish to aggregate. These will be summed. For
 #'     American Community Survey data, the margin of error will be calculated by
@@ -90,7 +90,7 @@ zi_aggregate <- function(.data, year, extensive = NULL, intensive = NULL,
   # }
 
   if (missing(year)){
-    cli::cli_abort("{.arg year} is required. Please provide a numeric value between {.val 2010} and {.val 2022}.")
+    cli::cli_abort("{.arg year} is required. Please provide a numeric value between {.val 2010} and {.val 2024}.")
   }
 
   if (!is.numeric(year)){
@@ -121,9 +121,9 @@ zi_aggregate <- function(.data, year, extensive = NULL, intensive = NULL,
     ))
   }
 
-  if (survey %in% c("acs1", "acs5") & !(year %in% c(2010:2022))){
+  if (survey %in% c("acs1", "acs5") & !(year %in% c(2010:2024))){
     cli::cli_abort(c(
-      "{.arg year} must be between {.val 2010} and {.val 2022} for {.arg survey} values {.val acs1} and {.val acs5}.",
+      "{.arg year} must be between {.val 2010} and {.val 2024} for {.arg survey} values {.val acs1} and {.val acs5}.",
       "i" = "You requested {.val {survey}} for {.val {year}}."
     ))
   }

--- a/R/zi_get_demographics.R
+++ b/R/zi_get_demographics.R
@@ -9,9 +9,10 @@
 #'     supports data for \code{"acs1"} and \code{"acs5"} from 2010 to 2024.
 #'     Different \code{survey} products are available for different years.
 #'     See the \code{survey} parameter for more details. Note that
-#'     \code{zi_get_geometry()} and \code{zi_list_zctas()} currently only
-#'     support ZCTA geometry data through 2023; 2024 geometry support is
-#'     pending a future release.
+#'     state- or county-scoped \code{zi_get_geometry()} and
+#'     \code{zi_list_zctas()} requests currently only support ZCTA geometry
+#'     data through 2023; full 2024 geometry support for those cases is
+#'     tracked in a follow-up issue (#104).
 #' @param variables A character scalar or vector of variable IDs.
 #' @param table A character scalar of a table ID (only one table may be
 #'     requested per call).

--- a/R/zi_get_demographics.R
+++ b/R/zi_get_demographics.R
@@ -6,9 +6,12 @@
 #'
 #'
 #' @param year A four-digit numeric scalar for year. \code{zippeR} currently
-#'     supports data for from 2010 to 2022. Different \code{survey} products
-#'     are available for different years. See the \code{survey} parameter
-#'     for more details
+#'     supports data for \code{"acs1"} and \code{"acs5"} from 2010 to 2024.
+#'     Different \code{survey} products are available for different years.
+#'     See the \code{survey} parameter for more details. Note that
+#'     \code{zi_get_geometry()} and \code{zi_list_zctas()} currently only
+#'     support ZCTA geometry data through 2023; 2024 geometry support is
+#'     pending a future release.
 #' @param variables A character scalar or vector of variable IDs.
 #' @param table A character scalar of a table ID (only one table may be
 #'     requested per call).
@@ -59,7 +62,7 @@ zi_get_demographics <- function(year, variables = NULL,
 
   # check inputs
   if (missing(year)){
-    cli::cli_abort("{.arg year} is required. Please provide a numeric value between {.val 2010} and {.val 2022}.")
+    cli::cli_abort("{.arg year} is required. Please provide a numeric value between {.val 2010} and {.val 2024}.")
   }
 
   if (!is.numeric(year)){
@@ -90,9 +93,9 @@ zi_get_demographics <- function(year, variables = NULL,
     ))
   }
 
-  if (survey %in% c("acs1", "acs5") & !(year %in% c(2010:2022))){
+  if (survey %in% c("acs1", "acs5") & !(year %in% c(2010:2024))){
     cli::cli_abort(c(
-      "{.arg year} must be between {.val 2010} and {.val 2022} for {.arg survey} values {.val acs1} and {.val acs5}.",
+      "{.arg year} must be between {.val 2010} and {.val 2024} for {.arg survey} values {.val acs1} and {.val acs5}.",
       "i" = "You requested {.val {survey}} for {.val {year}}."
     ))
   }

--- a/man/zi_aggregate.Rd
+++ b/man/zi_aggregate.Rd
@@ -24,9 +24,9 @@ plan to use for aggregating data. See Details below for formatting
 requirements.}
 
 \item{year}{A four-digit numeric scalar for year. \code{zippeR} currently
-supports data for from 2010 to 2022. Different \code{survey} products
-are available for different years. See the \code{survey} parameter
-for more details.}
+supports data for \code{"acs1"} and \code{"acs5"} from 2010 to 2024.
+Different \code{survey} products are available for different years.
+See the \code{survey} parameter for more details.}
 
 \item{extensive}{A character scalar or vector listing all extensive (i.e.
 count data) variables you wish to aggregate. These will be summed. For

--- a/man/zi_get_demographics.Rd
+++ b/man/zi_get_demographics.Rd
@@ -19,9 +19,10 @@ zi_get_demographics(
 supports data for \code{"acs1"} and \code{"acs5"} from 2010 to 2024.
 Different \code{survey} products are available for different years.
 See the \code{survey} parameter for more details. Note that
-\code{zi_get_geometry()} and \code{zi_list_zctas()} currently only
-support ZCTA geometry data through 2023; 2024 geometry support is
-pending a future release.}
+state- or county-scoped \code{zi_get_geometry()} and
+\code{zi_list_zctas()} requests currently only support ZCTA geometry
+data through 2023; full 2024 geometry support for those cases is
+tracked in a follow-up issue (#104).}
 
 \item{variables}{A character scalar or vector of variable IDs.}
 

--- a/man/zi_get_demographics.Rd
+++ b/man/zi_get_demographics.Rd
@@ -16,9 +16,12 @@ zi_get_demographics(
 }
 \arguments{
 \item{year}{A four-digit numeric scalar for year. \code{zippeR} currently
-supports data for from 2010 to 2022. Different \code{survey} products
-are available for different years. See the \code{survey} parameter
-for more details}
+supports data for \code{"acs1"} and \code{"acs5"} from 2010 to 2024.
+Different \code{survey} products are available for different years.
+See the \code{survey} parameter for more details. Note that
+\code{zi_get_geometry()} and \code{zi_list_zctas()} currently only
+support ZCTA geometry data through 2023; 2024 geometry support is
+pending a future release.}
 
 \item{variables}{A character scalar or vector of variable IDs.}
 

--- a/tests/testthat/test_zi_aggregate.R
+++ b/tests/testthat/test_zi_aggregate.R
@@ -76,6 +76,13 @@ test_that("zi_aggregate produces correct wide output", {
   expect_false("variable" %in% names(result))
 })
 
+test_that("zi_aggregate accepts the extended 2023/2024 acs5 year range", {
+  expect_no_error(zi_aggregate(zi_mo_pop, year = 2023, extensive = "B01003_001",
+                               survey = "acs5", zcta = c("630", "631")))
+  expect_no_error(zi_aggregate(zi_mo_pop, year = 2024, extensive = "B01003_001",
+                               survey = "acs5", zcta = c("630", "631")))
+})
+
 # test internal helpers: decennial extensive ----------------------------------
 
 # Decennial fixture: 6 ZCTAs across 2 ZCTA3s, 2 variables (one extensive, one intensive)

--- a/tests/testthat/test_zi_get_demographics.R
+++ b/tests/testthat/test_zi_get_demographics.R
@@ -52,6 +52,7 @@ test_that("acs5 supports the extended 2023/2024 year range", {
   skip_if_no_integration()
   skip_if(nchar(Sys.getenv("CENSUS_API_KEY")) == 0, "Census API key not available")
   expect_no_error(zi_get_demographics(year = 2023, survey = "acs5", variables = "B19083_001"))
+  expect_no_error(zi_get_demographics(year = 2024, survey = "acs5", variables = "B19083_001"))
 })
 
 # test positive-path assertions ------------------------------------------------

--- a/tests/testthat/test_zi_get_demographics.R
+++ b/tests/testthat/test_zi_get_demographics.R
@@ -48,6 +48,12 @@ test_that("correctly specified functions execute without error", {
   expect_no_error(zi_get_demographics(year = 2012, survey = "acs5", variables = c(pop = "B01003_001")))
 })
 
+test_that("acs5 supports the extended 2023/2024 year range", {
+  skip_if_no_integration()
+  skip_if(nchar(Sys.getenv("CENSUS_API_KEY")) == 0, "Census API key not available")
+  expect_no_error(zi_get_demographics(year = 2023, survey = "acs5", variables = "B19083_001"))
+})
+
 # test positive-path assertions ------------------------------------------------
 
 test_that("acs5 variables returns tidy output with expected schema", {


### PR DESCRIPTION
<!-- pr-skill-managed-start -->
## Summary

Fixes a year-range inconsistency bug where `zi_get_demographics()` and `zi_aggregate()` capped `acs1`/`acs5` survey years at 2022, blocking valid 2023/2024 ACS5 requests and creating an inconsistency with `zi_get_geometry()`'s broader year support.

## Implementation

- Extended the `acs1`/`acs5` year-range validation in `zi_get_demographics()` from `2010:2022` to `2010:2024` (validation check, roxygen `@param year`, and abort message).
- Found and fixed the identical, duplicated validation logic in `zi_aggregate()`.
- Regenerated `man/zi_get_demographics.Rd` and `man/zi_aggregate.Rd`.
- Added a `NEWS.md` bug-fix entry and a `CHANGELOG.md` `[Unreleased]` entry referencing this issue.
- Cross-referenced #104 (the related geometry-side gap) from `zi_get_demographics()`'s roxygen.

## Testing

- `devtools::test()`: 264 PASS, 0 FAIL.
- Live-verified against the real Census API: `zi_get_demographics(year = 2023, survey = "acs5")` and `zi_get_demographics(year = 2024, survey = "acs5")` both succeed (33,772 rows each).
- Added a live-network regression test (`tests/testthat/test_zi_get_demographics.R`) asserting both years succeed.
- Added a fast, non-network regression test (`tests/testthat/test_zi_aggregate.R`) for the 2023/2024 boundary using the bundled `zi_mo_pop` fixture — runs on CRAN/CI without a Census API key.
- Code-review gate: CLEAN after addressing missing CHANGELOG entry, missing `zi_aggregate()` fast-test coverage, and an overclaiming test title.
- **UAT**: user-confirmed passing for these `R/` changes.

## Closes

Closes #103

## Notes

- This PR intentionally does not extend `zi_get_geometry()`/`zi_list_zctas()`'s year support — that's tracked separately in #104, since it requires rebuilding `R/sysdata.rda` (a heavy, manual, out-of-Copilot data pipeline run).
<!-- pr-skill-managed-end -->
