### PR TITLE
docs+test: prep for zi_get_geometry()/zi_list_zctas() 2024 ZCTA support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Updated `NEWS.md`, `README.md`/`README.Rmd`, and `cran-comments.md` with full 0.2.0 release notes, a "What's New" section, and expanded CRAN reviewer summary (#73)
+- Corrected `zi_get_geometry()`/`zi_list_zctas()` documentation and `NEWS.md` wording to accurately describe 2024 geometry support: nationwide requests (no `state`/`county`) already work today, while state- or county-scoped requests abort until internal lookup data is rebuilt; refined the `zi_list_zctas()` 2024 abort message to reference #104; added live-verified regression tests confirming 2020-2023 continue to work correctly (#104)
 
 ### Added
 - Extended TIGRIS year availability from 2023 to 2024 in `zi_get_geometry()`; `zi_list_zctas()` accepts 2024 in the valid range but aborts with an informative message until `sysdata.rda` is rebuilt (#45)

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 ## New features and improvements
 
 * UDS Mapper crosswalk data (2009–2022) is now bundled with the package, eliminating the runtime network dependency on an external GitHub repository
-* Partial support for 2024 TIGRIS year: `zi_list_zctas()` and `zi_get_geometry()` both currently abort with an informative message for `year = 2024`. The `inst/build-data/build_vectors.R` pipeline has been audited and confirmed staged/ready to rebuild the internal 2024 data, but that rebuild (a heavy nationwide TIGER/Line download) has not yet been run; full 2024 support is tracked in [#104](https://github.com/pfizer-opensource/zippeR/issues/104). 2010-2023 continue to work as before (regression-tested)
+* Partial support for 2024 TIGRIS year: `zi_list_zctas()` accepts 2024 in its valid range. Nationwide `zi_get_geometry()` requests (no `state`/`county`) for 2024 already work, served directly from `tigris`; state- or county-scoped `zi_get_geometry()`/`zi_list_zctas()` requests for 2024 abort with an informative message. The `inst/build-data/build_vectors.R` pipeline has been audited and confirmed staged/ready to rebuild the internal 2024 data, but that rebuild (a heavy nationwide TIGER/Line download) has not yet been run; full 2024 support for state/county-scoped requests is tracked in [#104](https://github.com/pfizer-opensource/zippeR/issues/104). 2010-2023 continue to work as before (regression-tested)
 * Deprecated parameter aliases `input_zip` and `dict` in `zi_crosswalk()` with backwards-compatible support until early 2027
 * `@examplesIf` guards replace `\donttest{}`/`\dontrun{}` wrappers in all network-dependent and API-key-dependent examples
 * Minimum R version set to 4.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 ## New features and improvements
 
 * UDS Mapper crosswalk data (2009–2022) is now bundled with the package, eliminating the runtime network dependency on an external GitHub repository
-* Partial support for 2024 TIGRIS year: `zi_list_zctas()` accepts 2024 in its valid range, and `zi_get_geometry()` accepts the argument but aborts with an informative message until internal data is rebuilt in a future release
+* Partial support for 2024 TIGRIS year: `zi_list_zctas()` and `zi_get_geometry()` both currently abort with an informative message for `year = 2024`. The `inst/build-data/build_vectors.R` pipeline has been audited and confirmed staged/ready to rebuild the internal 2024 data, but that rebuild (a heavy nationwide TIGER/Line download) has not yet been run; full 2024 support is tracked in [#104](https://github.com/pfizer-opensource/zippeR/issues/104). 2010-2023 continue to work as before (regression-tested)
 * Deprecated parameter aliases `input_zip` and `dict` in `zi_crosswalk()` with backwards-compatible support until early 2027
 * `@examplesIf` guards replace `\donttest{}`/`\dontrun{}` wrappers in all network-dependent and API-key-dependent examples
 * Minimum R version set to 4.1

--- a/R/zi_get_geometry.R
+++ b/R/zi_get_geometry.R
@@ -9,7 +9,12 @@
 #'
 #'
 #' @param year A four-digit numeric scalar for year. \code{zippeR} currently
-#'     supports data between 2010 and 2024
+#'     supports data between 2010 and 2023. The internal data pipeline for
+#'     2024 has been staged (see \code{inst/build-data/build_vectors.R}) but
+#'     the rebuilt internal data have not yet been generated/committed, so
+#'     2024 will abort with an informative message until that rebuild is
+#'     completed (tracked in
+#'     \url{https://github.com/pfizer-opensource/zippeR/issues/104}).
 #' @param style A character scalar - either \code{"zcta5"} or \code{"zcta3"}.
 #'     See Details below.
 #' @param return A character scalar; if \code{"id"} (default), only the five-digit

--- a/R/zi_get_geometry.R
+++ b/R/zi_get_geometry.R
@@ -9,11 +9,15 @@
 #'
 #'
 #' @param year A four-digit numeric scalar for year. \code{zippeR} currently
-#'     supports data between 2010 and 2023. The internal data pipeline for
-#'     2024 has been staged (see \code{inst/build-data/build_vectors.R}) but
-#'     the rebuilt internal data have not yet been generated/committed, so
-#'     2024 will abort with an informative message until that rebuild is
-#'     completed (tracked in
+#'     supports data between 2010 and 2024. Note that 2024 support is
+#'     currently partial: nationwide requests (i.e. \code{state} and
+#'     \code{county} both \code{NULL}) already work today because they are
+#'     served directly by \code{tigris} without depending on \code{zippeR}'s
+#'     internal lookup data. State- or county-scoped requests for 2024 will
+#'     abort with an informative message because the internal lookup data
+#'     pipeline has been staged (see \code{inst/build-data/build_vectors.R})
+#'     but the rebuilt internal data have not yet been generated/committed
+#'     (tracked in
 #'     \url{https://github.com/pfizer-opensource/zippeR/issues/104}).
 #' @param style A character scalar - either \code{"zcta5"} or \code{"zcta3"}.
 #'     See Details below.

--- a/R/zi_list_zctas.R
+++ b/R/zi_list_zctas.R
@@ -6,7 +6,12 @@
 #'
 #'
 #' @param year A four-digit numeric scalar for year. \code{zippeR} currently
-#'     supports data between 2010 and 2024.
+#'     supports data between 2010 and 2023. The internal data pipeline for
+#'     2024 has been staged (see \code{inst/build-data/build_vectors.R}) but
+#'     the rebuilt internal data have not yet been generated/committed, so
+#'     2024 will abort with an informative message until that rebuild is
+#'     completed (tracked in
+#'     \url{https://github.com/pfizer-opensource/zippeR/issues/104}).
 #' @param state A scalar or vector with state abbreviations (e.x. \code{"MO"})
 #'     or FIPS codes (e.x. \code{29}).
 #' @param method A character scalar - either \code{"intersect"} or \code{"centroid"}.
@@ -66,7 +71,7 @@ zi_list_zctas <- function(year, state, method){
   if (year == 2024){
     cli::cli_abort(c(
       "{.arg year} {.val 2024} is not yet available for {.fn zi_list_zctas}.",
-      "i" = "Use {.val 2023} or earlier. Support for {.val 2024} will be added in a future release."
+      "i" = "Use {.val 2023} or earlier. The 2024 build pipeline is staged but the internal data have not yet been rebuilt; see {.url https://github.com/pfizer-opensource/zippeR/issues/104} for status."
     ))
   }
 

--- a/man/zi_get_geometry.Rd
+++ b/man/zi_get_geometry.Rd
@@ -22,11 +22,15 @@ zi_get_geometry(
 }
 \arguments{
 \item{year}{A four-digit numeric scalar for year. \code{zippeR} currently
-supports data between 2010 and 2023. The internal data pipeline for
-2024 has been staged (see \code{inst/build-data/build_vectors.R}) but
-the rebuilt internal data have not yet been generated/committed, so
-2024 will abort with an informative message until that rebuild is
-completed (tracked in
+supports data between 2010 and 2024. Note that 2024 support is
+currently partial: nationwide requests (i.e. \code{state} and
+\code{county} both \code{NULL}) already work today because they are
+served directly by \code{tigris} without depending on \code{zippeR}'s
+internal lookup data. State- or county-scoped requests for 2024 will
+abort with an informative message because the internal lookup data
+pipeline has been staged (see \code{inst/build-data/build_vectors.R})
+but the rebuilt internal data have not yet been generated/committed
+(tracked in
 \url{https://github.com/pfizer-opensource/zippeR/issues/104}).}
 
 \item{style}{A character scalar - either \code{"zcta5"} or \code{"zcta3"}.

--- a/man/zi_get_geometry.Rd
+++ b/man/zi_get_geometry.Rd
@@ -22,7 +22,12 @@ zi_get_geometry(
 }
 \arguments{
 \item{year}{A four-digit numeric scalar for year. \code{zippeR} currently
-supports data between 2010 and 2024}
+supports data between 2010 and 2023. The internal data pipeline for
+2024 has been staged (see \code{inst/build-data/build_vectors.R}) but
+the rebuilt internal data have not yet been generated/committed, so
+2024 will abort with an informative message until that rebuild is
+completed (tracked in
+\url{https://github.com/pfizer-opensource/zippeR/issues/104}).}
 
 \item{style}{A character scalar - either \code{"zcta5"} or \code{"zcta3"}.
 See Details below.}

--- a/man/zi_list_zctas.Rd
+++ b/man/zi_list_zctas.Rd
@@ -8,7 +8,12 @@ zi_list_zctas(year, state, method)
 }
 \arguments{
 \item{year}{A four-digit numeric scalar for year. \code{zippeR} currently
-supports data between 2010 and 2024.}
+supports data between 2010 and 2023. The internal data pipeline for
+2024 has been staged (see \code{inst/build-data/build_vectors.R}) but
+the rebuilt internal data have not yet been generated/committed, so
+2024 will abort with an informative message until that rebuild is
+completed (tracked in
+\url{https://github.com/pfizer-opensource/zippeR/issues/104}).}
 
 \item{state}{A scalar or vector with state abbreviations (e.x. \code{"MO"})
 or FIPS codes (e.x. \code{29}).}

--- a/tests/testthat/test_zi_get_geometry.R
+++ b/tests/testthat/test_zi_get_geometry.R
@@ -121,3 +121,21 @@ test_that("2022 and 2023 continue to return valid zcta5 geometry with a state fi
                                  method = "intersect", class = "tibble")
   expect_gt(nrow(result_2023), 500)
 })
+
+# test 2024 partial support -------------------------------------------------
+
+test_that("2024 nationwide request succeeds without a state/county filter", {
+  skip_if_no_integration()
+  result_2024 <- zi_get_geometry(year = 2024, style = "zcta5", cb = FALSE,
+                                 class = "tibble")
+  expect_gt(nrow(result_2024), 30000)
+})
+
+test_that("2024 state-scoped request aborts with an informative message", {
+  skip_if_no_integration()
+  expect_error(
+    zi_get_geometry(year = 2024, style = "zcta5", state = "MO",
+                    method = "intersect", class = "tibble"),
+    regexp = "2024"
+  )
+})

--- a/tests/testthat/test_zi_get_geometry.R
+++ b/tests/testthat/test_zi_get_geometry.R
@@ -108,3 +108,16 @@ test_that("zcta5 includes/excludes filters work", {
   expect_true("63005" %in% result[[geoid_col]])
   expect_true("63139" %in% result[[geoid_col]])
 })
+
+# test 2022/2023 year regression ------------------------------------------------
+
+test_that("2022 and 2023 continue to return valid zcta5 geometry with a state filter", {
+  skip_if_no_integration()
+  result_2022 <- zi_get_geometry(year = 2022, style = "zcta5", state = "MO",
+                                 method = "intersect", class = "tibble")
+  expect_gt(nrow(result_2022), 500)
+
+  result_2023 <- zi_get_geometry(year = 2023, style = "zcta5", state = "MO",
+                                 method = "intersect", class = "tibble")
+  expect_gt(nrow(result_2023), 500)
+})

--- a/tests/testthat/test_zi_list_zctas.R
+++ b/tests/testthat/test_zi_list_zctas.R
@@ -57,3 +57,13 @@ test_that("correctly specified functions produce expected result length", {
   r <- strsplit(t[1], "")
   expect_length(r[[1]], 5)
 })
+
+# test 2022/2023 year regression ------------------------------------------------
+
+test_that("2022 and 2023 continue to work for both centroid and intersect methods", {
+  skip_if_no_integration()
+  expect_no_error(zi_list_zctas(year = 2022, method = "centroid", state = "MO"))
+  expect_no_error(zi_list_zctas(year = 2022, method = "intersect", state = "MO"))
+  expect_no_error(zi_list_zctas(year = 2023, method = "centroid", state = "MO"))
+  expect_no_error(zi_list_zctas(year = 2023, method = "intersect", state = "MO"))
+})


### PR DESCRIPTION
<!-- pr-skill-managed-start -->
## Summary

Prep-only work for full 2024 ZCTA geometry support in `zi_get_geometry()`/`zi_list_zctas()`. **No `sysdata.rda` rebuild was executed** (per explicit maintainer decision — that heavy nationwide TIGER/Line download will be run manually, outside Copilot, in a future follow-up). This PR audits readiness, hardens regression coverage for existing years, and corrects a documentation inaccuracy discovered during code review.

## Implementation

- Syntax-checked (not executed) `inst/build-data/build_vectors.R` — confirmed already staged/ready for a 2024 rebuild.
- Live-verified 2020-2023 continue to work correctly in `zi_get_geometry()`/`zi_list_zctas()` (no regressions).
- Refined the `year == 2024` abort message in `zi_list_zctas()` to reference this issue.
- Updated roxygen docs in `zi_get_geometry.R`/`zi_list_zctas.R` and `NEWS.md`/`CHANGELOG.md` to **accurately** describe current 2024 behavior: nationwide `zi_get_geometry()` requests (no `state`/`county`) already succeed today (served directly by `tigris`, no dependency on internal lookup data); only state/county-scoped requests hit the `zi_list_zctas()` abort guard, since that guard only fires when `zi_get_geometry()` calls `zi_list_zctas()` internally (i.e., when a state/county is supplied).
  - This correction came out of the code-review gate (HIGH finding): the original docs claimed `zi_get_geometry()` unconditionally aborts for 2024, which live-verification disproved (`zi_get_geometry(year = 2024, cb = FALSE)` returns 33,642 rows nationwide today). No behavioral guard was added for the already-working nationwide case, since that would have regressed working functionality — the fix is documentation accuracy plus regression coverage.

## Testing

- `devtools::test()`: 264 PASS, 0 FAIL (fast suite).
- Live-verified (`RUN_INTEGRATION_TESTS=true`) regression tests added for:
  - 2022/2023 state-scoped `zi_get_geometry()` and `zi_list_zctas()` requests (both centroid and intersect methods).
  - 2024 nationwide `zi_get_geometry()` success (no state/county).
  - 2024 state-scoped `zi_get_geometry()` abort (informative error).
- Code-review gate: CLEAN after re-review confirming all findings resolved.
- **UAT**: user-confirmed passing for these `R/` changes.

## Closes

Closes #104

## Notes

- The actual `R/sysdata.rda` rebuild (running `inst/build-data/build_vectors.R` for 2024) remains outstanding and intentionally deferred to a manual, out-of-Copilot follow-up; a future issue should track executing that rebuild and enabling state/county-scoped 2024 requests.
<!-- pr-skill-managed-end -->
