### PR TITLE
chore: force-link macOS Homebrew sf deps to resolve CI warnings

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -71,6 +71,15 @@ jobs:
         if: runner.os == 'macOS' && steps.cache-macos-syslibs.outputs.cache-hit != 'true'
         run: brew install udunits gdal proj
 
+      # The macOS runner image ships udunits/gdal/proj pre-installed but
+      # unlinked, so on a cache miss `brew install` treats them as already
+      # present and skips linking, only emitting a "not linked" warning.
+      # Force-link them so pkg-config/*-config paths sf/terra expect are
+      # guaranteed to resolve, without touching the cache mechanism itself.
+      - name: Link macOS Homebrew dependencies for sf
+        if: runner.os == 'macOS'
+        run: brew link --overwrite udunits gdal proj
+
       - name: Install Linux specific dependencies for sf
         if: runner.os == 'Linux'
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rebuilt `R/sysdata.rda` with full 2024 ZCTA geometry data (intersect and centroid vectors, reference tables); state- and county-scoped `zi_get_geometry()`/`zi_list_zctas()` requests for year 2024 now work end-to-end, matching nationwide support added previously (#91)
 
 ### Changed
+- Added a `brew link --overwrite udunits gdal proj` step after the macOS `sf` dependency install in `R-CMD-check.yaml`, so a cache miss no longer silently leaves the runner-image-preinstalled formulae unlinked with a `##[warning] ... not linked` annotation (#122)
 - Re-pointed the vendored workflow toolkit upstream from `pfizer-evgen/rwd-agent-skills` to its renamed home `pfizer-evgen/agentic-dev`, and synced all 84 non-overridden `vendored-exact` files to byte parity with current upstream (#116)
 - Migrated the monolithic `pull_request` skill to the `pr-gates` cluster (`pr_orchestrator` plus five gate skills); `pr_orchestrator/SKILL.md` is now the entry point for opening and updating PRs (#116)
 - Retired the `r-developer` and `workflow-steward` agent personas upstream; R expertise now lives in `developer` via the module-gated R "hat" partial, and `workflow-steward` was renamed `scrum-master` (#116)


### PR DESCRIPTION
<!-- pr-skill-managed-start -->
## Summary

Resolves the macOS `brew link` "already installed, it's just not linked" warnings observed on the `R-CMD-check.yaml` macOS leg (`udunits`, `gdal`, `proj`).

## Implementation

Per the [implementation plan on #122](https://github.com/pfizer-opensource/zippeR/issues/122#issuecomment-5243715783): the macOS runner image ships these three Homebrew formulae pre-installed but unlinked. On a `cache-macos-syslibs` cache miss, `brew install` detects them as already present and skips linking, only emitting a `##[warning]` rather than failing loudly. Added a `brew link --overwrite udunits gdal proj` step (macOS-only) immediately after the existing install step, scoped to just those three formulae rather than a blanket relink, so `sf`/`terra`'s `pkg-config`/`*-config` lookups are guaranteed to resolve linked Cellar paths regardless of cache state. The caching mechanism itself (`cache-macos-syslibs`) is untouched, per the issue's explicit out-of-scope note.

## Testing

- Validated `.github/workflows/R-CMD-check.yaml` YAML syntax with `python3 -c "import yaml; yaml.safe_load(...)"`.
- Will confirm via this PR's own `R-CMD-check` macOS/release CI run that no `##[warning] ... is already installed, it's just not linked` lines appear and the job still succeeds.

## Closes

Closes #122

## Notes

No `R/` source changes — UAT gate not applicable.

_Code review finding (MEDIUM, accepted):_ if the macOS Homebrew cache restore is ever partial/corrupt for one of `udunits`/`gdal`/`proj`, the new `brew link --overwrite` step will now hard-fail (`No such keg`) rather than surfacing only a warning. Accepted as a fail-fast improvement over a later, less-informative build failure; not fixed in this PR.
<!-- pr-skill-managed-end -->

---
<sub>Co-authored-by: Copilot</sub>
