### PR TITLE
chore: move Epic I to Recently Shipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Added a `brew link --overwrite udunits gdal proj` step after the macOS `sf` dependency install in `R-CMD-check.yaml`, so a cache miss no longer silently leaves the runner-image-preinstalled formulae unlinked with a `##[warning] ... not linked` annotation (#122)
+- Retired `[Epic I] CI & Development Infrastructure Health` (#110) from `docs/ROADMAP.md` to `Recently Shipped`; all five sub-issues (#102, #113, #114, #115, #122) shipped, resolving the caching-layer defects, checks-not-firing gap, Node.js 20 deprecation warnings, and macOS Homebrew warnings
 - Re-pointed the vendored workflow toolkit upstream from `pfizer-evgen/rwd-agent-skills` to its renamed home `pfizer-evgen/agentic-dev`, and synced all 84 non-overridden `vendored-exact` files to byte parity with current upstream (#116)
 - Migrated the monolithic `pull_request` skill to the `pr-gates` cluster (`pr_orchestrator` plus five gate skills); `pr_orchestrator/SKILL.md` is now the entry point for opening and updating PRs (#116)
 - Retired the `r-developer` and `workflow-steward` agent personas upstream; R expertise now lives in `developer` via the module-gated R "hat" partial, and `workflow-steward` was renamed `scrum-master` (#116)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -31,9 +31,8 @@ _No epics in progress._
 
 ```mermaid
 graph TD
-  I["#110 Epic I — CI health"] --> J["#111 Epic J — v0.3.0 Release"]
-  H["#109 Epic H — API ergonomics"] -.optional.-> J
+  H["#109 Epic H — API ergonomics"] -.optional.-> J["#111 Epic J — v0.3.0 Release"]
 ```
 
-- [Epic I] should land before [Epic J] so release checks run against a trustworthy pipeline.
+- [Epic I] closed 2026-08-10 — its precondition on [Epic J] (release checks running against a trustworthy pipeline) is satisfied; the dependency edge is resolved and removed from the graph.
 - [Epic H] is optional for the release; #108 (`zi_census_api_key()`) is a good candidate to include if it lands in time.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,5 +1,5 @@
 ---
-last_updated: "2026-08-06"
+last_updated: "2026-08-10"
 ---
 # Roadmap — zippeR
 
@@ -9,7 +9,6 @@ _No epics in progress._
 
 ## Next (planned)
 
-- **[Epic I] CI & Development Infrastructure Health** (#110) — Restore reliable CI check execution and correct the caching layer; 0/2 sub-issues closed
 - **[Epic H] User-Facing API Ergonomics & Dependency Reduction** (#109) — Self-contained `zi_`-prefixed API surface plus Phase 3 dependency decisions; 0/3 sub-issues closed
 - **[Epic J] v0.3.0 Release** (#111) — Ship 2024 ZCTA support to CRAN; sub-issues to be filed at kickoff
 
@@ -19,6 +18,7 @@ _No epics in progress._
 
 ## Recently Shipped
 
+- **[Epic I] CI & Development Infrastructure Health** (#110) — closed 2026-08-10
 - **[Epic E] Code & Test Quality Audit** (#48) — closed 2026-08-06
 - **[Epic G] CRAN Release Preparation** (#79) — closed 2026-06-02
 - **[Epic F] New Features & Enhancements** (#49) — closed 2026-06-01


### PR DESCRIPTION
<!-- pr-skill-managed-start -->
## Summary

Closes out [Epic I] CI & Development Infrastructure Health (#110) — all five sub-issues shipped, epic retrospective posted, roadmap moved to Recently Shipped.

## Implementation

_no-handoff: #110 — mechanical roadmap-move commit as part of epic close; the `## Epic Retrospective` comment already posted on #110 is the durable planning/outcome record for this closure, per `epic_retrospective/SKILL.md`'s contract._

Moved the Epic I roadmap entry from `Next` to the top of `Recently Shipped` in `docs/ROADMAP.md`, bumped the `last_updated` frontmatter, resolved a stale dependency edge in the `## Epic dependencies` mermaid graph that still showed Epic I as an open blocker of Epic J (flagged by code review), and added a `CHANGELOG.md` entry recording the epic's closure and its five resolved sub-issues.

## Testing

- Verified `docs/ROADMAP.md`'s Recently Shipped list stays newest-first and at 8 entries (under the 10-entry cap, no pruning needed).
- Manual review of the rendered mermaid diagram diff.
- Fresh-context pre-PR QC pass: clean across repo-level QC, doc-staleness audit, and repo-specific checklist (all N/A — no `R/` changes).

## Closes

Closes #110

## Notes

Docs-only change — no `R/` source, no UAT gate applicable.
<!-- pr-skill-managed-end -->

---
<sub>Co-authored-by: Copilot</sub>
