### PR TITLE
docs: register Epic K on the roadmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rebuilt `R/sysdata.rda` with full 2024 ZCTA geometry data (intersect and centroid vectors, reference tables); state- and county-scoped `zi_get_geometry()`/`zi_list_zctas()` requests for year 2024 now work end-to-end, matching nationwide support added previously (#91)
 
 ### Changed
+- Registered `[Epic K] Vendored Workflow Toolkit Adoption & Governance` (#123) on `docs/ROADMAP.md` under `Next`, with a preferred-but-not-blocking dependency edge to `[Epic J]` (#111) and a note that #120 gates #118 and #119 (#123)
 - Added a `brew link --overwrite udunits gdal proj` step after the macOS `sf` dependency install in `R-CMD-check.yaml`, so a cache miss no longer silently leaves the runner-image-preinstalled formulae unlinked with a `##[warning] ... not linked` annotation (#122)
 - Retired `[Epic I] CI & Development Infrastructure Health` (#110) from `docs/ROADMAP.md` to `Recently Shipped`; all five sub-issues (#102, #113, #114, #115, #122) shipped, resolving the caching-layer defects, checks-not-firing gap, Node.js 20 deprecation warnings, and macOS Homebrew warnings
 - Re-pointed the vendored workflow toolkit upstream from `pfizer-evgen/rwd-agent-skills` to its renamed home `pfizer-evgen/agentic-dev`, and synced all 84 non-overridden `vendored-exact` files to byte parity with current upstream (#116)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,5 +1,5 @@
 ---
-last_updated: "2026-08-10"
+last_updated: "2026-08-11"
 ---
 # Roadmap — zippeR
 
@@ -11,6 +11,7 @@ _No epics in progress._
 
 - **[Epic H] User-Facing API Ergonomics & Dependency Reduction** (#109) — Self-contained `zi_`-prefixed API surface plus Phase 3 dependency decisions; 0/3 sub-issues closed
 - **[Epic J] v0.3.0 Release** (#111) — Ship 2024 ZCTA support to CRAN; sub-issues to be filed at kickoff
+- **[Epic K] Vendored Workflow Toolkit Adoption & Governance** (#123) — Make the vendored toolkit's labels and ADR corpus real, so lifecycle gates resolve from decisions rather than absence; 0/3 sub-issues closed
 
 ## Later (aspirational)
 
@@ -32,7 +33,9 @@ _No epics in progress._
 ```mermaid
 graph TD
   H["#109 Epic H — API ergonomics"] -.optional.-> J["#111 Epic J — v0.3.0 Release"]
+  K["#123 Epic K — Toolkit adoption"] -.preferred.-> J
 ```
 
 - [Epic I] closed 2026-08-10 — its precondition on [Epic J] (release checks running against a trustworthy pipeline) is satisfied; the dependency edge is resolved and removed from the graph.
 - [Epic H] is optional for the release; #108 (`zi_census_api_key()`) is a good candidate to include if it lands in time.
+- [Epic K] is preferred-but-not-blocking for [Epic J] — the release cycle runs more meaningfully once lifecycle gates resolve from recorded decisions, but no release artifact depends on it. Internally, #120 gates both #118 and #119.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -11,7 +11,7 @@ _No epics in progress._
 
 - **[Epic H] User-Facing API Ergonomics & Dependency Reduction** (#109) — Self-contained `zi_`-prefixed API surface plus Phase 3 dependency decisions; 0/3 sub-issues closed
 - **[Epic J] v0.3.0 Release** (#111) — Ship 2024 ZCTA support to CRAN; sub-issues to be filed at kickoff
-- **[Epic K] Vendored Workflow Toolkit Adoption & Governance** (#123) — Make the vendored toolkit's labels and ADR corpus real, so lifecycle gates resolve from decisions rather than absence; 0/3 sub-issues closed
+- **[Epic K] Vendored Workflow Toolkit Adoption & Governance** (#123) — Make the vendored toolkit's labels and ADR corpus real, so lifecycle gates resolve from decisions rather than absence; 0/4 sub-issues closed
 
 ## Later (aspirational)
 


### PR DESCRIPTION
<!-- pr-skill-managed-start -->
## Summary

Completes the `epic/SKILL.md` Phase 4 roadmap registration for `[Epic K] Vendored Workflow Toolkit Adoption & Governance` (#123), which an earlier session could not perform because it was explicitly scoped to GitHub-side changes only (a parallel developer session held the worktree at the time). This PR is that deferred registration step, done as a follow-up rather than an oversight.

## Implementation

- `docs/ROADMAP.md`
  - Added **[Epic K]** (#123) under `## Next (planned)`, after [Epic H] (#109) and [Epic J] (#111) — 0/4 sub-issues closed.
  - Added a `K -.preferred.-> J` edge to the `## Epic dependencies` mermaid graph, plus a prose note that Epic K is preferred-but-not-blocking for Epic J, and that #120 internally gates both #118 and #119.
  - Bumped `last_updated` frontmatter from `2026-08-10` to `2026-08-11`.
- `CHANGELOG.md` — added the corresponding `[Unreleased]` → `Changed` entry referencing #123.
- A second commit corrects the entry's sub-issue count from `0/3` to `0/4`, since #126 was filed under Epic K after the first commit landed.

No `R/` source, tests, or workflows are touched.

**Disclosure — hand-edited derived artifact.** The `## Epic dependencies` mermaid graph in `docs/ROADMAP.md` is declared a derived artifact by `epic_dependency/SKILL.md` ("do not hand-edit it"), and this commit hand-edits it anyway. This was done knowingly: `epic_dependency/SKILL.md`'s `map` operation is currently unrunnable in this repo — it depends on a `## Epics` block anchor that `docs/ROADMAP.md` does not have. `roadmap/SKILL.md` was likewise **not** used for this edit, for the same root cause: its Phase 0 halts when the `## Epics` block is missing. The edit instead follows the existing local ROADMAP prose/mermaid format for consistency with prior entries (e.g. PR #112's Epic H/I/J registration). The root cause is filed as **#126** (`[Tech Debt] docs/ROADMAP.md does not match the schema roadmap/SKILL.md parses`) under Epic K, and this same disclosure is already recorded in #126's body.

## Testing

Documentation-only change; none of the Pre-PR QC checklist items (`devtools::document()`, `devtools::test()`, `devtools::check()`) apply — all are conditioned on changes to `R/`, `DESCRIPTION`, `NAMESPACE`, or roxygen2 blocks, and this diff touches none of those. UAT is likewise not triggered, since it only applies to `R/` changes. Verified instead via the code-review gate:

- All referenced issue numbers exist and are in the state the roadmap text implies: #123 (Epic K) open; #120, #118, #119, #126 open and match the epic's actual sub-issue list, with #120 gating #118 and #119 as stated.
- Mermaid graph syntax is valid; the new `K -.preferred.-> J` edge is consistent with the prose note beneath it.
- `last_updated` frontmatter bumped correctly.
- CHANGELOG entry conforms to Keep a Changelog and sits under the correct `[Unreleased]` → `Changed` heading.
- No broken internal links or markdown syntax errors.

## Closes

Refs #123 — this PR does not close any issue. Epic K remains open with its four sub-issues (#120, #118, #119, #126) outstanding; this PR only registers it on the roadmap.

## Notes

_no-handoff:_ #123 is an epic and carries no `<!-- implementation-plan-v1 -->` comment to hand off or transition — there is nothing to hand off. Direct prior art: PR #112 was an equivalent docs-only roadmap PR (`Refs #48`) that recorded the same `_no-handoff:_` rationale for the same reason.

**Why split from epic filing.** Epic K (#123) was filed in an earlier session explicitly scoped to "no local file changes," because a parallel developer session held the worktree at the time. That left the roadmap-registration half of `epic/SKILL.md` Phase 4 incomplete until this branch.
<!-- pr-skill-managed-end -->

---
<sub>Co-authored-by: Copilot</sub>
