### PR TITLE
refactor: convert dplyr filter/select/mutate/arrange call sites to Base R

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rebuilt `R/sysdata.rda` with full 2024 ZCTA geometry data (intersect and centroid vectors, reference tables); state- and county-scoped `zi_get_geometry()`/`zi_list_zctas()` requests for year 2024 now work end-to-end, matching nationwide support added previously (#91)
 
 ### Changed
+- Converted all `dplyr::filter()`, `select()`, `mutate()`, and `arrange()` call sites in `zi_aggregate.R`, `zi_crosswalk.R`, `zi_get_demographics.R`, `zi_get_geometry.R`, `zi_list_zctas.R`, `zi_load_crosswalk.R`, `zi_load_labels.R`, and `zi_prep_hud.R` to Base R equivalents, as part of Epic L's dplyr removal; behavior is unchanged, no `rlang` introduced (#130)
 - Registered `[Epic K] Vendored Workflow Toolkit Adoption & Governance` (#123) on `docs/ROADMAP.md` under `Next`, with a preferred-but-not-blocking dependency edge to `[Epic J]` (#111) and a note that #120 gates #118 and #119 (#123)
 - Added a `brew link --overwrite udunits gdal proj` step after the macOS `sf` dependency install in `R-CMD-check.yaml`, so a cache miss no longer silently leaves the runner-image-preinstalled formulae unlinked with a `##[warning] ... not linked` annotation (#122)
 - Retired `[Epic I] CI & Development Infrastructure Health` (#110) from `docs/ROADMAP.md` to `Recently Shipped`; all five sub-issues (#102, #113, #114, #115, #122) shipped, resolving the caching-layer defects, checks-not-firing gap, Node.js 20 deprecation warnings, and macOS Homebrew warnings

--- a/R/zi_aggregate.R
+++ b/R/zi_aggregate.R
@@ -226,8 +226,9 @@ zi_aggregate <- function(.data, year, extensive = NULL, intensive = NULL,
   }
 
   # prep data
-  .data <- dplyr::mutate(.data, ZCTA3 = substr(GEOID, 1, 3), .before = GEOID)
-  .data <- dplyr::arrange(.data, ZCTA3)
+  .data$ZCTA3 <- substr(.data$GEOID, 1, 3)
+  .data <- .data[, c("ZCTA3", setdiff(names(.data), "ZCTA3"))]
+  .data <- .data[order(.data$ZCTA3), ]
 
   # call underlying tidycensus data
   if (survey %in% c("sf1", "sf3")){
@@ -253,8 +254,8 @@ zi_aggregate <- function(.data, year, extensive = NULL, intensive = NULL,
     } else if (extensive_id & intensive_id){
 
       ## subset data
-      extensive_df <- dplyr::filter(.data, variable %in% extensive)
-      intensive_df <- dplyr::filter(.data, variable %in% intensive)
+      extensive_df <- .data[.data$variable %in% extensive, ]
+      intensive_df <- .data[.data$variable %in% intensive, ]
 
       ## calculate weights
       weights <- zi_census_weights(year = year, key = key)
@@ -266,7 +267,7 @@ zi_aggregate <- function(.data, year, extensive = NULL, intensive = NULL,
 
         ## combine
         out <- dplyr::bind_rows(extensive_df, intensive_df)
-        out <- dplyr::arrange(out, ZCTA3, variable)
+        out <- out[order(out$ZCTA3, out$variable), ]
       } else {
         out <- NULL
       }
@@ -296,8 +297,8 @@ zi_aggregate <- function(.data, year, extensive = NULL, intensive = NULL,
     } else if (extensive_id & intensive_id){
 
       ## subset data
-      extensive_df <- dplyr::filter(.data, variable %in% extensive)
-      intensive_df <- dplyr::filter(.data, variable %in% intensive)
+      extensive_df <- .data[.data$variable %in% extensive, ]
+      intensive_df <- .data[.data$variable %in% intensive, ]
 
       ## calculate weights
       weights <- zi_acs_weights(year = year, survey = survey, key = key)
@@ -309,7 +310,7 @@ zi_aggregate <- function(.data, year, extensive = NULL, intensive = NULL,
 
         ## combine
         out <- dplyr::bind_rows(extensive_df, intensive_df)
-        out <- dplyr::arrange(out, ZCTA3, variable)
+        out <- out[order(out$ZCTA3, out$variable), ]
       } else {
         out <- NULL
       }
@@ -320,7 +321,7 @@ zi_aggregate <- function(.data, year, extensive = NULL, intensive = NULL,
   if (!is.null(out)){
     # optionally subset
     if (!is.null(zcta)){
-      out <- dplyr::filter(out, ZCTA3 %in% zcta)
+      out <- out[out$ZCTA3 %in% zcta, ]
     }
 
     # optionally pivot
@@ -354,7 +355,7 @@ zi_aggregate <- function(.data, year, extensive = NULL, intensive = NULL,
       wide_names <- c("ZCTA3", sort(wide_names))
 
       ## re-order columns alphabetically
-      out <- dplyr::select(out, dplyr::all_of(wide_names))
+      out <- out[, wide_names]
 
     }
   }
@@ -425,9 +426,10 @@ zi_census_weights <- function(year, key){
 
   if (!is.null(out)){
     ## prep data
-    out <- dplyr::mutate(out, ZCTA3 = substr(GEOID, 1, 3), .before = GEOID)
-    out <- dplyr::select(out, -NAME)
-    out <- dplyr::arrange(out, ZCTA3)
+    out$ZCTA3 <- substr(out$GEOID, 1, 3)
+    out <- out[, c("ZCTA3", setdiff(names(out), "ZCTA3"))]
+    out <- out[, setdiff(names(out), "NAME")]
+    out <- out[order(out$ZCTA3), ]
 
     ## group by and sum
     totals <- dplyr::group_by(out, ZCTA3)
@@ -437,10 +439,10 @@ zi_census_weights <- function(year, key){
     out <- dplyr::left_join(out, totals, by = "ZCTA3")
 
     ## calculate proportions
-    out <- dplyr::mutate(out, weight = value / total_pop)
+    out$weight <- out$value / out$total_pop
 
     ## subset
-    out <- dplyr::select(out, ZCTA3, GEOID, weight)
+    out <- out[, c("ZCTA3", "GEOID", "weight")]
   }
 
   ## return output
@@ -455,7 +457,7 @@ zi_acs_extensive <- function(.data){
   ZCTA3 = variable = estimate = moe = NULL
 
   ## square MOEs
-  .data <- dplyr::mutate(.data, moe = moe^2)
+  .data$moe <- .data$moe^2
 
   ## group by and sum
   .data <- dplyr::group_by(.data, ZCTA3, variable)
@@ -464,7 +466,7 @@ zi_acs_extensive <- function(.data){
                             moe = sum(moe, na.rm = TRUE))
 
   ## square root of MOE
-  .data <- dplyr::mutate(.data, moe = sqrt(moe))
+  .data$moe <- sqrt(.data$moe)
 
   ## return output
   return(.data)
@@ -518,10 +520,11 @@ zi_acs_weights <- function(year, survey, key){
 
   if (!is.null(out)){
     ## prep data
-    out <- dplyr::mutate(out, GEOID = sub("^\\S+ ", "", NAME))
-    out <- dplyr::mutate(out, ZCTA3 = substr(GEOID, 1, 3), .before = GEOID)
-    out <- dplyr::select(out, -NAME)
-    out <- dplyr::arrange(out, ZCTA3)
+    out$GEOID <- sub("^\\S+ ", "", out$NAME)
+    out$ZCTA3 <- substr(out$GEOID, 1, 3)
+    out <- out[, c("ZCTA3", setdiff(names(out), "ZCTA3"))]
+    out <- out[, setdiff(names(out), "NAME")]
+    out <- out[order(out$ZCTA3), ]
 
     ## group by and sum
     totals <- dplyr::group_by(out, ZCTA3)
@@ -531,10 +534,10 @@ zi_acs_weights <- function(year, survey, key){
     out <- dplyr::left_join(out, totals, by = "ZCTA3")
 
     ## calculate proportions
-    out <- dplyr::mutate(out, weight = estimate / total_pop)
+    out$weight <- out$estimate / out$total_pop
 
     ## subset
-    out <- dplyr::select(out, ZCTA3, GEOID, weight)
+    out <- out[, c("ZCTA3", "GEOID", "weight")]
   }
 
   ## return output

--- a/R/zi_crosswalk.R
+++ b/R/zi_crosswalk.R
@@ -280,9 +280,9 @@ zi_crosswalk <- function(.data, input_var, zip_source = "UDS", source_var,
       dict <- zi_prep_hud(dict, by = by, return_max = return_max)
 
       if (return == "id"){
-        dict <- dplyr::select(dict, zip5, source_geoid = geoid)
+        dict <- stats::setNames(dict[, c("zip5", "geoid")], c("zip5", "source_geoid"))
       } else if (return == "all"){
-        dict <- dplyr::select(dict, zip5, geoid, dplyr::everything())
+        dict <- dict[, c("zip5", "geoid", setdiff(names(dict), c("zip5", "geoid")))]
       }
 
       source_resultQN <- "geoid"
@@ -292,9 +292,11 @@ zi_crosswalk <- function(.data, input_var, zip_source = "UDS", source_var,
       dict <- zi_load_uds(year = year)
 
       if (return == "id"){
-        dict <- dplyr::select(dict, zip5 = ZIP, source_zcta = ZCTA)
+        dict <- stats::setNames(dict[, c("ZIP", "ZCTA")], c("zip5", "source_zcta"))
       } else if (return == "all"){
-        dict <- dplyr::select(dict, zip5 = ZIP, zcta = ZCTA, dplyr::everything())
+        rest <- setdiff(names(dict), c("ZIP", "ZCTA"))
+        dict <- dict[, c("ZIP", "ZCTA", rest)]
+        names(dict)[1:2] <- c("zip5", "zcta")
       }
 
       source_resultQN <- "zcta"
@@ -309,13 +311,14 @@ zi_crosswalk <- function(.data, input_var, zip_source = "UDS", source_var,
     dict <- zip_source
 
     if (return == "id"){
-      dict <- dplyr::select(dict, dplyr::all_of(source_varQN), dplyr::all_of(source_resultQN))
+      dict <- dict[, c(source_varQN, source_resultQN)]
 
       source_new_result <- paste0("source_", source_resultQN)
       names(dict)[names(dict) == source_resultQN] <- source_new_result
 
     } else if (return == "all"){
-      dict <- dplyr::select(dict, dplyr::all_of(source_varQN), dplyr::all_of(source_resultQN), dplyr::everything())
+      cols <- c(source_varQN, source_resultQN)
+      dict <- dict[, c(cols, setdiff(names(dict), cols))]
     }
   }
 

--- a/R/zi_get_demographics.R
+++ b/R/zi_get_demographics.R
@@ -147,7 +147,7 @@ zi_get_demographics <- function(year, variables = NULL,
 
     ## prep data
     if (!is.null(out)){
-      out <- dplyr::mutate(out, GEOID = sub("^\\S+ ", "", NAME))
+      out$GEOID <- sub("^\\S+ ", "", out$NAME)
     }
 
   }
@@ -155,12 +155,12 @@ zi_get_demographics <- function(year, variables = NULL,
   # tidy if data are returned
   if (!is.null(out)){
     ## remove additional cols and re-arrange
-    out <- dplyr::select(out, -NAME)
-    out <- dplyr::arrange(out, GEOID)
+    out <- out[, setdiff(names(out), "NAME")]
+    out <- out[order(out$GEOID), ]
 
     ## optionally subset
     if (!is.null(zcta)){
-      out <- dplyr::filter(out, GEOID %in% zcta)
+      out <- out[out$GEOID %in% zcta, ]
     }
   }
 

--- a/R/zi_get_geometry.R
+++ b/R/zi_get_geometry.R
@@ -342,7 +342,7 @@ zi_get_zcta5 <- function(year, return = "id", state, county, territory, cb,
       }
 
       ## subset
-      out <- dplyr::filter(out, GEOID %in% zcta_vec)
+      out <- out[out$GEOID %in% zcta_vec, ]
 
     } else if (!is.null(state) & !is.null(county)){
 
@@ -364,7 +364,7 @@ zi_get_zcta5 <- function(year, return = "id", state, county, territory, cb,
         }
 
         ## subset
-        out <- dplyr::filter(out, GEOID %in% zcta_vec)
+        out <- out[out$GEOID %in% zcta_vec, ]
       } else {
         out <- NULL
       }
@@ -382,10 +382,10 @@ zi_get_zcta5 <- function(year, return = "id", state, county, territory, cb,
       if (is.null(territory)){
 
         ## all territories not including American Samoa
-        out <- dplyr::filter(out, !(substr(GEOID, 1, 3) %in% c("006", "007", "008", "009", "969")))
+        out <- out[!(substr(out$GEOID, 1, 3) %in% c("006", "007", "008", "009", "969")), ]
 
         ## American Samoa
-        out <- dplyr::filter(out, GEOID != "96799")
+        out <- out[out$GEOID != "96799", ]
 
       } else if (!is.null(territory)){
 
@@ -408,7 +408,7 @@ zi_get_zcta5 <- function(year, return = "id", state, county, territory, cb,
 
       ## subset
       if (!is.null(excludes)){
-        out <- dplyr::filter(out, !(GEOID %in% excludes))
+        out <- out[!(out$GEOID %in% excludes), ]
       }
 
     }
@@ -416,16 +416,16 @@ zi_get_zcta5 <- function(year, return = "id", state, county, territory, cb,
     # subset based on starts with
     if (!is.null(out)){
       if (!is.null(starts_with)){
-        out <- dplyr::filter(out, substr(GEOID, 1, 2) %in% starts_with)
+        out <- out[substr(out$GEOID, 1, 2) %in% starts_with, ]
       }
 
       # subset columns based on return
       if (return == "id"){
-        out <- dplyr::select(out, GEOID)
+        out <- out[, "GEOID"]
       }
 
       # order output
-      out <- dplyr::arrange(out, GEOID)
+      out <- out[order(out$GEOID), ]
     }
   }
 
@@ -445,8 +445,8 @@ zi_process_county <- function(cb, state, county, year, zcta, method, style){
 
   # if tigris call successful, wrangle
   if (!is.null(counties)){
-    counties <- dplyr::select(counties, GEOID)
-    counties <- dplyr::filter(counties, GEOID %in% county)
+    counties <- counties[, "GEOID"]
+    counties <- counties[counties$GEOID %in% county, ]
 
     # calculate centroids
     if (method == "centroid"){
@@ -456,9 +456,9 @@ zi_process_county <- function(cb, state, county, year, zcta, method, style){
     # create simplified data
     if (style == "zcta5"){
       if (year < 2020){
-        zcta <- dplyr::select(zcta, GEOID10)
+        zcta <- zcta[, "GEOID10"]
       } else if (year >= 2020) {
-        zcta <- dplyr::select(zcta, GEOID20)
+        zcta <- zcta[, "GEOID20"]
       }
     }
 
@@ -521,9 +521,9 @@ zi_get_zcta3 <- function(year, state, county, territory, cb, starts_with,
 
     ## subset based on year
     if (year < 2020){
-      out <- dplyr::filter(out, ZCTA3 %in% zcta_vec)
+      out <- out[out$ZCTA3 %in% zcta_vec, ]
     } else if (year >= 2020){
-      out <- dplyr::filter(out, ZCTA3 %in% zcta_vec)
+      out <- out[out$ZCTA3 %in% zcta_vec, ]
     }
 
   } else if (!is.null(state) & !is.null(county)){
@@ -539,7 +539,7 @@ zi_get_zcta3 <- function(year, state, county, territory, cb, starts_with,
       zcta_vec <- zcta_vec[!(zcta_vec %in% excludes)]
 
       ## subset based on year
-      out <- dplyr::filter(out, ZCTA3 %in% zcta_vec)
+      out <- out[out$ZCTA3 %in% zcta_vec, ]
     } else {
       out <- NULL
     }
@@ -550,7 +550,7 @@ zi_get_zcta3 <- function(year, state, county, territory, cb, starts_with,
     if (is.null(territory)){
 
       ## all territories not including American Samoa
-      out <- dplyr::filter(out, !(ZCTA3 %in% c("006", "007", "008", "009", "969")))
+      out <- out[!(out$ZCTA3 %in% c("006", "007", "008", "009", "969")), ]
 
       ## American Samoa
       out <- sf::st_difference(out, samoa_bounding_box)
@@ -588,7 +588,7 @@ zi_get_zcta3 <- function(year, state, county, territory, cb, starts_with,
 
     ## remove exclusions
     if (!is.null(excludes)){
-      out <- dplyr::filter(out, !(ZCTA3 %in% excludes))
+      out <- out[!(out$ZCTA3 %in% excludes), ]
     }
 
   }
@@ -596,11 +596,11 @@ zi_get_zcta3 <- function(year, state, county, territory, cb, starts_with,
   # subset based on starts with
   if (!is.null(out)){
     if (!is.null(starts_with)){
-      out <- dplyr::filter(out, substr(ZCTA3, 1, 2) %in% starts_with)
+      out <- out[substr(out$ZCTA3, 1, 2) %in% starts_with, ]
     }
 
     # order output
-    out <- dplyr::arrange(out, ZCTA3)
+    out <- out[order(out$ZCTA3), ]
   }
 
   # return output

--- a/R/zi_list_zctas.R
+++ b/R/zi_list_zctas.R
@@ -95,9 +95,9 @@ zi_list_zctas <- function(year, state, method){
 
   # subset based on method
   if (method == "centroid"){
-    sub <- dplyr::filter(reference_centroids, fips %in% statez & year == yearz)
+    sub <- reference_centroids[reference_centroids$fips %in% statez & reference_centroids$year == yearz, ]
   } else if (method == "intersect"){
-    sub <- dplyr::filter(reference_intersects, fips %in% statez & year == yearz)
+    sub <- reference_intersects[reference_intersects$fips %in% statez & reference_intersects$year == yearz, ]
   }
 
   sub <- sub$obj

--- a/R/zi_load_crosswalk.R
+++ b/R/zi_load_crosswalk.R
@@ -149,7 +149,8 @@ zi_load_uds <- function(year) {
   }
 
   all_data <- readRDS(crosswalk_path)
-  out <- dplyr::filter(all_data, .data$year == .env$year)
+  requested_year <- year
+  out <- all_data[all_data$year == requested_year, ]
   out$year <- NULL
 
   # check validation

--- a/R/zi_load_labels.R
+++ b/R/zi_load_labels.R
@@ -133,8 +133,8 @@ zi_load_labels_uds <- function(year){
   out <- zi_load_uds(year = year)
 
   # format output
-  out <- dplyr::select(out, zip5 = ZIP, label_city = PO_NAME, label_state = STATE,
-                       label_type = ZIP_TYPE)
+  out <- stats::setNames(out[, c("ZIP", "PO_NAME", "STATE", "ZIP_TYPE")],
+                   c("zip5", "label_city", "label_state", "label_type"))
 
   # return output
   return(out)

--- a/R/zi_prep_hud.R
+++ b/R/zi_prep_hud.R
@@ -90,14 +90,25 @@ zi_prep_hud <- function(.data, by, return_max = TRUE){
   out <- out[order(out$zip5, out$state, out$geoid), ]
   out <- dplyr::group_by(out, zip5, state)
 
+  # ave() groups by combining vectors via split(); unlike dplyr::group_by(),
+  # split() drops NA keys into per-row singleton groups instead of grouping
+  # them together. Coercing to factors with exclude = NULL preserves NA as a
+  # real grouping level, matching dplyr's grouped max() semantics exactly.
+  # These must be (re)computed against out's row order at the point ave()
+  # is called, since return_max reorders out by geoid beforehand.
+
   if (return_max){
     out <- out[order(out$geoid), ]
-    grp_max <- stats::ave(out$ratio, out$zip5, out$state,
+    zip5_grp <- factor(out$zip5, exclude = NULL)
+    state_grp <- factor(out$state, exclude = NULL)
+    grp_max <- stats::ave(out$ratio, zip5_grp, state_grp,
                     FUN = function(x) max(x, na.rm = TRUE))
     out <- out[!is.na(out$ratio) & out$ratio == grp_max, ]
     out <- dplyr::slice(out, 1)
   } else if (!return_max){
-    grp_max <- stats::ave(out$ratio, out$zip5, out$state,
+    zip5_grp <- factor(out$zip5, exclude = NULL)
+    state_grp <- factor(out$state, exclude = NULL)
+    grp_max <- stats::ave(out$ratio, zip5_grp, state_grp,
                     FUN = function(x) max(x, na.rm = TRUE))
     out$max <- ifelse(out$ratio == grp_max, TRUE, FALSE)
   }

--- a/R/zi_prep_hud.R
+++ b/R/zi_prep_hud.R
@@ -68,11 +68,14 @@ zi_prep_hud <- function(.data, by, return_max = TRUE){
   hud <- dplyr::rename_with(.data, tolower)
 
   if (by == "residential"){
-    hud <- dplyr::select(hud, zip5 = zip, geoid, state, ratio = res_ratio)
+    hud <- stats::setNames(hud[, c("zip", "geoid", "state", "res_ratio")],
+                     c("zip5", "geoid", "state", "ratio"))
   } else if (by == "commercial"){
-    hud <- dplyr::select(hud, zip5 = zip, geoid, state, ratio = bus_ratio)
+    hud <- stats::setNames(hud[, c("zip", "geoid", "state", "bus_ratio")],
+                     c("zip5", "geoid", "state", "ratio"))
   } else if (by == "total"){
-    hud <- dplyr::select(hud, zip5 = zip, geoid, state, ratio = tot_ratio)
+    hud <- stats::setNames(hud[, c("zip", "geoid", "state", "tot_ratio")],
+                     c("zip5", "geoid", "state", "ratio"))
   }
 
   # convert state_fips using static lookup (avoids network download)
@@ -81,28 +84,28 @@ zi_prep_hud <- function(.data, by, return_max = TRUE){
   state_df$state <- toupper(state_df$state)
 
   out <- dplyr::left_join(hud, state_df, by = "state")
-  out <- dplyr::select(out, zip5, geoid, state, state_fips, ratio)
+  out <- out[, c("zip5", "geoid", "state", "state_fips", "ratio")]
 
   # identify max
-  out <- dplyr::arrange(out, zip5, state, geoid)
+  out <- out[order(out$zip5, out$state, out$geoid), ]
   out <- dplyr::group_by(out, zip5, state)
 
   if (return_max){
-    out <- dplyr::arrange(out, geoid)
-    out <- dplyr::filter(out, !is.na(ratio))
-    out <- dplyr::filter(out, ratio == max(ratio, na.rm = TRUE))
+    out <- out[order(out$geoid), ]
+    grp_max <- stats::ave(out$ratio, out$zip5, out$state,
+                    FUN = function(x) max(x, na.rm = TRUE))
+    out <- out[!is.na(out$ratio) & out$ratio == grp_max, ]
     out <- dplyr::slice(out, 1)
   } else if (!return_max){
-    out <- dplyr::mutate(out,
-                         max = ifelse(ratio == max(ratio, na.rm = TRUE),
-                                      TRUE, FALSE)
-    )
+    grp_max <- stats::ave(out$ratio, out$zip5, out$state,
+                    FUN = function(x) max(x, na.rm = TRUE))
+    out$max <- ifelse(out$ratio == grp_max, TRUE, FALSE)
   }
 
   out <- dplyr::ungroup(out)
 
   # subset on max and prep output
-  out <- dplyr::filter(out, !is.na(state))
+  out <- out[!is.na(out$state), ]
 
   # return output
   return(out)

--- a/tests/testthat/test_zi_prep_hud.R
+++ b/tests/testthat/test_zi_prep_hud.R
@@ -54,3 +54,40 @@ test_that("return_max = FALSE includes max column", {
   result <- zi_prep_hud(mo_xwalk, by = "residential", return_max = FALSE)
   expect_true("max" %in% names(result))
 })
+
+test_that("grouped max is computed correctly when zip5-state keys contain NA", {
+  # regression test - a Base R ave()-based grouping must treat NA keys the
+  # same way dplyr::group_by() does (grouping NAs together), not as
+  # per-row singleton groups (which would silently mark every row as max).
+  # Uses wholly synthetic data, so no need to skip on CRAN.
+
+  na_xwalk <- data.frame(
+    ZIP = c(NA_character_, NA_character_, "63103"),
+    GEOID = c("29001", "29003", "29510"),
+    RES_RATIO = c(0.3, 0.7, 1),
+    BUS_RATIO = c(0.3, 0.7, 1),
+    OTH_RATIO = c(0.3, 0.7, 1),
+    TOT_RATIO = c(0.3, 0.7, 1),
+    CITY = c("A", "B", "SAINT LOUIS"),
+    STATE = c("MO", "MO", "MO")
+  )
+
+  result_all <- zi_prep_hud(na_xwalk, by = "residential", return_max = FALSE)
+  na_rows <- result_all[is.na(result_all$zip5), ]
+
+  expect_equal(nrow(na_rows), 2)
+  # only the row with the higher ratio (0.7) within the shared NA zip5/state
+  # group should be flagged as the max - both should NOT be TRUE
+  expect_equal(sum(na_rows$max), 1)
+  expect_true(na_rows$max[na_rows$ratio == 0.7])
+
+  # return_max = TRUE must collapse the same NA-keyed group to a single row
+  # bearing the true max ratio (0.7, GEOID 29003) - not the lowest-GEOID row
+  # from an unfixed implementation that treats every NA-keyed row as tied
+  result_max <- zi_prep_hud(na_xwalk, by = "residential", return_max = TRUE)
+  na_row_max <- result_max[is.na(result_max$zip5), ]
+
+  expect_equal(nrow(na_row_max), 1)
+  expect_equal(na_row_max$ratio, 0.7)
+  expect_equal(na_row_max$geoid, "29003")
+})


### PR DESCRIPTION
<!-- pr-skill-managed-start -->
## Summary

Converts all `dplyr::filter()`, `dplyr::select()`, `dplyr::mutate()`, and `dplyr::arrange()` call sites (~62 across 8 of 9 in-scope files) to Base R equivalents, per [ADR-0005](../blob/main/docs/decisions/ADR-0005-dplyr-removal-decision.md) and [Epic L] #129. This is the first of five scoped conversion sub-issues executing the dplyr-removal decision.

## Implementation

Per the [implementation plan](https://github.com/pfizer-opensource/zippeR/issues/130#issuecomment-5267087986) on #130: `filter()` → `[` row-subsetting; `select()` (including `all_of()`/`everything()`/rename patterns) → `[`, `%in%`, `stats::setNames()`; `mutate()` → direct `$`/`[[` assignment; `arrange()` → `[order(...), ]`. Converted file-by-file (`zi_list_zctas.R`, `zi_load_crosswalk.R`, `zi_load_labels.R`, `zi_prep_hud.R`, `zi_get_demographics.R`, `zi_crosswalk.R`, `zi_get_geometry.R`, `zi_aggregate.R`), running that file's test suite after each conversion. `zi_label.R` had no in-scope call sites (only `left_join`) and was left untouched.

`dplyr::rename()`/`rename_with()`/`bind_rows()`/`left_join()`/`group_by()`/`summarise()`/`slice()` call sites are intentionally out of scope — owned by #131 (joins), #132 (grouped aggregation), and #133 (rename/bind_rows/pipeline-glue).

One notable implementation detail: `zi_prep_hud.R`'s `return_max`/`!return_max` branches perform `filter`/`mutate` while the tibble is still grouped by an out-of-scope `dplyr::group_by()` call. Converting those naively to plain Base R would have silently switched a per-group `max()` to a global max. Resolved using `stats::ave()` to compute the group-aware max before the Base R subset/assignment, preserving exact behavior.

**Code review (Gate 2) caught and this PR fixes two real bugs** in that `ave()`-based logic before it shipped: (1) `ave()`/`split()` doesn't group `NA` grouping keys together the way `dplyr::group_by()` does — fixed by coercing the grouping vectors to `factor(x, exclude = NULL)`; (2) the `return_max = TRUE` branch reorders rows by `geoid` after the grouping factors were computed, misaligning `ave()`'s output — fixed by recomputing the grouping factors after each branch's own row reordering. Regression tests were added for both.

## Testing

- `devtools::test()` (full suite): 285 passed, 0 failed, 32 skipped (integration tests requiring live network/API access) — includes 6 new regression tests in `test_zi_prep_hud.R` covering the NA-key grouping edge case under both `return_max` branches
- `RUN_INTEGRATION_TESTS=true devtools::test(filter="zi_get_geometry")`: 43 passed, 0 failed (verifies `sf`-object subsetting under load; 1 pre-existing unrelated warning from `sf::st_difference`, an untouched code path)
- `devtools::document()`: no NAMESPACE/man changes (internal call sites only)
- `devtools::check()`: 0 errors, 0 warnings, 1 NOTE (`unable to verify current time` — environment clock check, unrelated to this change)
- Manual operator UAT completed **twice** per repo's Human-in-the-loop rule for `R/` changes: first pass verified `zi_prep_hud()` (grouped-max logic), `zi_load_uds()`, and `zi_crosswalk()` against bundled fixtures and real ZIP-code input data; second, targeted pass re-verified `zi_prep_hud()` specifically after the code-review-driven NA-grouping fix. Both confirmed passing.

## Closes

Closes #130

## Notes

Flagging for the #132 (grouped-aggregation) implementer: once `dplyr::group_by()`/`ungroup()` are removed from `zi_prep_hud.R` in that follow-up issue, the `stats::ave()`-based max logic added here can likely collapse into a simpler ungrouped form — worth revisiting then.
<!-- pr-skill-managed-end -->

---
<sub>Co-authored-by: Copilot</sub>
